### PR TITLE
fix: separate LLM provider and model metadata

### DIFF
--- a/app/llm/claude.go
+++ b/app/llm/claude.go
@@ -40,6 +40,10 @@ func (c *ClaudeClient) Name() string {
 	return "claude"
 }
 
+func (c *ClaudeClient) Model() string {
+	return c.model
+}
+
 const claudeMaxRetries = 3
 const claudeRetryDelay = 6 * time.Second
 

--- a/app/llm/client.go
+++ b/app/llm/client.go
@@ -13,6 +13,11 @@ type Client interface {
 	Name() string
 }
 
+// Modeler is implemented by LLM clients that can expose the configured model name.
+type Modeler interface {
+	Model() string
+}
+
 // Config contains LLM configuration
 type Config struct {
 	Provider string // "ollama", "gemini", "claude", "openai", "groq"

--- a/app/llm/gemini.go
+++ b/app/llm/gemini.go
@@ -39,6 +39,10 @@ func (c *GeminiClient) Name() string {
 	return "gemini"
 }
 
+func (c *GeminiClient) Model() string {
+	return c.model
+}
+
 const geminiMaxRetries = 3
 const geminiRetryDelay = 6 * time.Second
 

--- a/app/llm/groq.go
+++ b/app/llm/groq.go
@@ -39,6 +39,10 @@ func (c *GroqClient) Name() string {
 	return "groq"
 }
 
+func (c *GroqClient) Model() string {
+	return c.model
+}
+
 const groqMaxRetries = 3
 const groqRetryDelay = 6 * time.Second
 

--- a/app/llm/ollama.go
+++ b/app/llm/ollama.go
@@ -38,6 +38,9 @@ func (c *OllamaClient) Name() string {
 	return "ollama"
 }
 
+func (c *OllamaClient) Model() string {
+	return c.model
+}
 func (c *OllamaClient) Generate(ctx context.Context, prompt string) (string, error) {
 	url := fmt.Sprintf("%s/api/generate", c.baseURL)
 

--- a/app/llm/openai.go
+++ b/app/llm/openai.go
@@ -39,6 +39,10 @@ func (c *OpenAIClient) Name() string {
 	return "openai"
 }
 
+func (c *OpenAIClient) Model() string {
+	return c.model
+}
+
 const openaiMaxRetries = 3
 const openaiRetryDelay = 6 * time.Second
 

--- a/app/service/reports.go
+++ b/app/service/reports.go
@@ -131,10 +131,11 @@ func (s *ReportsService) Generate(ctx context.Context, payload *reports.Generate
 
 	// Convert metrics to API format
 	metricsData := ConvertMetrics(calcMetrics)
+	providerName, modelName := llmMetadata(s.llmClient)
 
 	// Store report in database
 	debuglog.Log("storing report in database")
-	reportID, err := s.storeReport(ctx, payload, narrative, calcMetrics, queryResult)
+	reportID, err := s.storeReport(ctx, payload, narrative, calcMetrics, queryResult, providerName, modelName)
 	if err != nil {
 		return nil, err
 	}
@@ -157,8 +158,8 @@ func (s *ReportsService) Generate(ctx context.Context, payload *reports.Generate
 		Metrics:          metricsData,
 		ChartSuggestions: chartSuggestions,
 		CreatedAt:        time.Now().Format(time.RFC3339),
-		LlmModel:         s.llmClient.Name(),
-		LlmProvider:      s.llmClient.Name(),
+		LlmModel:         modelName,
+		LlmProvider:      providerName,
 	}, nil
 }
 
@@ -194,7 +195,7 @@ func suggestToReports(in []charts.Suggestion) []*reports.ChartSuggestion {
 	return out
 }
 
-func (s *ReportsService) storeReport(ctx context.Context, payload *reports.GenerateReportPayload, narrative *story.NarrativeContent, calcMetrics *metrics.Metrics, queryResult *queryrunner.Result) (string, error) {
+func (s *ReportsService) storeReport(ctx context.Context, payload *reports.GenerateReportPayload, narrative *story.NarrativeContent, calcMetrics *metrics.Metrics, queryResult *queryrunner.Result, providerName, modelName string) (string, error) {
 	narrativeJSON, _ := json.Marshal(narrative)
 	metricsJSON, _ := json.Marshal(calcMetrics)
 	statsJSON, _ := json.Marshal(map[string]interface{}{
@@ -210,9 +211,23 @@ func (s *ReportsService) storeReport(ctx context.Context, payload *reports.Gener
 		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 		RETURNING id
 	`, payload.SavedQueryID, payload.SQL, narrative.Headline, narrativeJSON, metricsJSON, statsJSON,
-		s.llmClient.Name(), s.llmClient.Name(), true).Scan(&reportID)
+		modelName, providerName, true).Scan(&reportID)
 
 	return reportID, err
+}
+
+func llmMetadata(client llm.Client) (providerName, modelName string) {
+	if client == nil {
+		return "", ""
+	}
+	providerName = client.Name()
+	modelName = providerName
+	if modeler, ok := client.(llm.Modeler); ok {
+		if model := strings.TrimSpace(modeler.Model()); model != "" {
+			modelName = model
+		}
+	}
+	return providerName, modelName
 }
 
 func (s *ReportsService) Get(ctx context.Context, payload *reports.GetPayload) (*reports.Report, error) {

--- a/test/e2e/reports_e2e_test.go
+++ b/test/e2e/reports_e2e_test.go
@@ -218,12 +218,6 @@ func TestReportsGenerateE2E(t *testing.T) {
 		if len(report.Narrative.Takeaways) == 0 {
 			t.Error("generate: expected takeaways")
 		}
-		if report.LlmProvider != "e2e" {
-			t.Errorf("generate: provider = %q, want %q", report.LlmProvider, "e2e")
-		}
-		if report.LlmModel != "e2e-test-model" {
-			t.Errorf("generate: model = %q, want %q", report.LlmModel, "e2e-test-model")
-		}
 	})
 
 	t.Run("Generate_ValidationError", func(t *testing.T) {

--- a/test/e2e/reports_e2e_test.go
+++ b/test/e2e/reports_e2e_test.go
@@ -218,6 +218,12 @@ func TestReportsGenerateE2E(t *testing.T) {
 		if len(report.Narrative.Takeaways) == 0 {
 			t.Error("generate: expected takeaways")
 		}
+		if report.LlmProvider != "e2e" {
+			t.Errorf("generate: provider = %q, want %q", report.LlmProvider, "e2e")
+		}
+		if report.LlmModel != "e2e-test-model" {
+			t.Errorf("generate: model = %q, want %q", report.LlmModel, "e2e-test-model")
+		}
 	})
 
 	t.Run("Generate_ValidationError", func(t *testing.T) {

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -53,6 +53,8 @@ func (m *e2eLLM) Generate(ctx context.Context, prompt string) (string, error) {
 
 func (m *e2eLLM) Name() string { return "e2e" }
 
+func (m *e2eLLM) Model() string { return "e2e-test-model" }
+
 var _ llm.Client = (*e2eLLM)(nil)
 
 // StartPostgres starts a Postgres container and returns it and the connection string.


### PR DESCRIPTION
## Linked Issue
Closes #33

## What changed
- added optional `Model()` metadata support for LLM clients
- updated report generation to capture provider and model separately
- persisted `llm_provider` and `llm_model` with distinct values
- returned provider/model fields correctly in report responses
- added E2E assertion to verify provider/model separation

## Why
Reports were using the same value for provider and model, which reduced observability and traceability for generated narratives.

## Test plan
- [x] `go test ./app/llm`
- [ ] `go test ./app/service ./test/e2e -run TestReportsGenerateE2E -count=1` (blocked locally by known macOS cgo build issue in `pg_query_go`)
- [ ] all CI checks pass

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Separate LLM provider and model metadata throughout report generation and persistence to improve observability of generated narratives.

New Features:
- Expose optional model metadata via a new Modeler interface on LLM clients and implement it for all concrete providers.

Bug Fixes:
- Persist and return distinct LLM provider and model values in reports instead of using a single shared identifier.

Enhancements:
- Centralize LLM provider/model resolution in a helper to gracefully handle clients without explicit model metadata.

Tests:
- Extend E2E report generation tests to assert that provider and model fields are stored and returned separately.