### PR TITLE
fix(ci): remove stale coverage artifact upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,13 +55,6 @@ jobs:
         env:
           TESTCONTAINERS_RYUK_DISABLED: "true"
         run: make test
-      - name: Upload coverage
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238
-        if: always()
-        with:
-          files: ./coverage.out
-          fail_ci_if_error: false
-
   # Build verification
   build:
     name: Build


### PR DESCRIPTION
## Linked Issue
Closes #35

## What changed
- removed `Upload coverage` step from `.github/workflows/ci.yml`
- eliminated the `coverage.out` upload reference that was not produced by `make test`

## Why
The CI test flow does not generate `coverage.out`, so uploading it is stale and misleading. Removing the step aligns workflow behavior with actual outputs.

## Test plan
- [x] workflow YAML diff reviewed
- [ ] all CI checks pass on this PR

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

CI:
- Remove the Codecov coverage upload step that referenced a non-existent coverage.out artifact.