### PR TITLE
fix: resolve issue 34, 25, and 22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 GO ?= go
 GOLANGCI_LINT ?= golangci-lint
 GOA ?= goa
+GOA_VERSION ?= v3.24.1
 # Use a user-writable module cache to avoid permission issues with system GOMODCACHE (e.g. root-owned ~/go/pkg/mod).
 GOMODCACHE ?= $(HOME)/.gomodcache
 export GOMODCACHE
@@ -144,7 +145,7 @@ generate:
 	@echo "🔧 Generating API code..."
 	@if ! command -v goa >/dev/null 2>&1; then \
 		echo "Installing Goa..."; \
-		$(GO) install goa.design/goa/v3/cmd/goa@latest; \
+		$(GO) install goa.design/goa/v3/cmd/goa@$(GOA_VERSION); \
 	fi
 	$(GO) generate ./...
 	$(GOA) gen github.com/pgquerynarrative/pgquerynarrative/api/design

--- a/app/service/reports.go
+++ b/app/service/reports.go
@@ -85,8 +85,8 @@ func (s *ReportsService) Generate(ctx context.Context, payload *reports.Generate
 		columnTypes[i] = col.Type
 	}
 
-	// Chart suggestions from result shape
-	chartSuggestions := suggestToReports(charts.Suggest(columnNames, columnTypes, queryResult.Rows))
+	// Rule-based chart suggestions from result shape (base ordering).
+	ruleSuggestions := charts.Suggest(columnNames, columnTypes, queryResult.Rows)
 
 	// Profile columns
 	profiles := metrics.ProfileColumns(columnNames, queryResult.Rows)
@@ -128,6 +128,10 @@ func (s *ReportsService) Generate(ctx context.Context, payload *reports.Generate
 		// or temporarily unavailable.
 		narrative = buildFallbackNarrative(queryResult.RowCount, calcMetrics.PerfSuggestions)
 	}
+	// Optional LLM pass: reorder/add one primary chart recommendation on top
+	// of rules so chart choice can better align with the generated story.
+	finalSuggestions := s.applyLLMChartRecommendation(ctx, narrative.Headline, columnNames, columnTypes, queryResult.RowCount, ruleSuggestions)
+	chartSuggestions := suggestToReports(finalSuggestions)
 
 	// Convert metrics to API format
 	metricsData := ConvertMetrics(calcMetrics)
@@ -193,6 +197,119 @@ func suggestToReports(in []charts.Suggestion) []*reports.ChartSuggestion {
 		}
 	}
 	return out
+}
+
+func (s *ReportsService) applyLLMChartRecommendation(ctx context.Context, headline string, columnNames, columnTypes []string, rowCount int, base []charts.Suggestion) []charts.Suggestion {
+	if len(base) == 0 || s.llmClient == nil {
+		return base
+	}
+	prompt := buildChartRecommendationPrompt(headline, columnNames, columnTypes, rowCount, base)
+	raw, err := s.llmClient.Generate(ctx, prompt)
+	if err != nil {
+		return base
+	}
+	chartType, reason := parseChartRecommendation(raw)
+	if chartType == "" {
+		return base
+	}
+	label := chartTypeLabel(chartType)
+	if label == "" {
+		return base
+	}
+	if strings.TrimSpace(reason) == "" {
+		reason = "LLM recommended this chart to support the narrative emphasis."
+	}
+	// Move suggested chart to front if it already exists, otherwise prepend.
+	out := make([]charts.Suggestion, 0, len(base)+1)
+	out = append(out, charts.Suggestion{
+		ChartType: chartType,
+		Label:     label,
+		Reason:    reason,
+	})
+	for _, s := range base {
+		if s.ChartType == chartType {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+func buildChartRecommendationPrompt(headline string, columnNames, columnTypes []string, rowCount int, base []charts.Suggestion) string {
+	var b strings.Builder
+	b.WriteString("You are selecting one best chart type for a report.\n")
+	b.WriteString("Allowed chart_type values: bar, line, pie, area, table.\n")
+	b.WriteString("Return STRICT JSON only with keys chart_type and reason.\n")
+	b.WriteString(`Example: {"chart_type":"line","reason":"Shows time trend clearly."}` + "\n\n")
+	b.WriteString("Narrative headline: ")
+	b.WriteString(headline)
+	b.WriteString("\nRow count: ")
+	b.WriteString(strconv.Itoa(rowCount))
+	b.WriteString("\nColumns:\n")
+	for i := range columnNames {
+		b.WriteString("- ")
+		b.WriteString(columnNames[i])
+		if i < len(columnTypes) {
+			b.WriteString(" (")
+			b.WriteString(columnTypes[i])
+			b.WriteString(")")
+		}
+		b.WriteString("\n")
+	}
+	b.WriteString("Rule-based suggestions:\n")
+	for _, s := range base {
+		b.WriteString("- ")
+		b.WriteString(s.ChartType)
+		b.WriteString(": ")
+		b.WriteString(s.Reason)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func parseChartRecommendation(raw string) (chartType, reason string) {
+	type rec struct {
+		ChartType string `json:"chart_type"`
+		Reason    string `json:"reason"`
+	}
+	trimmed := strings.TrimSpace(raw)
+	var r rec
+	if err := json.Unmarshal([]byte(trimmed), &r); err == nil {
+		return normalizeChartType(r.ChartType), strings.TrimSpace(r.Reason)
+	}
+	lower := strings.ToLower(trimmed)
+	for _, t := range []string{"line", "bar", "pie", "area", "table"} {
+		if strings.Contains(lower, t) {
+			return t, strings.TrimSpace(trimmed)
+		}
+	}
+	return "", ""
+}
+
+func normalizeChartType(v string) string {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "bar", "line", "pie", "area", "table":
+		return strings.ToLower(strings.TrimSpace(v))
+	default:
+		return ""
+	}
+}
+
+func chartTypeLabel(chartType string) string {
+	switch chartType {
+	case "bar":
+		return "Bar chart"
+	case "line":
+		return "Line chart"
+	case "pie":
+		return "Pie chart"
+	case "area":
+		return "Area chart"
+	case "table":
+		return "Table"
+	default:
+		return ""
+	}
 }
 
 func (s *ReportsService) storeReport(ctx context.Context, payload *reports.GenerateReportPayload, narrative *story.NarrativeContent, calcMetrics *metrics.Metrics, queryResult *queryrunner.Result, providerName, modelName string) (string, error) {

--- a/frontend/src/components/layout.tsx
+++ b/frontend/src/components/layout.tsx
@@ -1,4 +1,4 @@
-import { NavLink, Outlet } from "react-router-dom";
+import { NavLink, Outlet, useLocation } from "react-router-dom";
 import { cn } from "@/lib/utils";
 import { useTheme } from "@/contexts/theme-context";
 import { LayoutDashboard, Terminal, Bookmark, FileText, Settings, PanelLeftClose, PanelLeft, Moon, Sun } from "lucide-react";
@@ -15,6 +15,11 @@ const navItems = [
 export default function Layout() {
   const [collapsed, setCollapsed] = useState(false);
   const { theme, setTheme } = useTheme();
+  const location = useLocation();
+  const currentPageLabel =
+    navItems.find((item) => item.to !== "/" && location.pathname.startsWith(item.to))?.label ||
+    navItems.find((item) => item.to === location.pathname)?.label ||
+    "Dashboard";
 
   return (
     <div className="flex h-screen overflow-hidden relative z-10 text-foreground">
@@ -90,7 +95,13 @@ export default function Layout() {
 
       {/* Main: content above background layers; id for skip link target */}
       <main id="main-content" className="flex-1 overflow-auto min-h-0 border-l border-transparent dark:border-border/30" tabIndex={-1}>
-        <div className="max-w-6xl mx-auto px-6 py-8">
+        <div className="sticky top-0 z-20 border-b border-border/70 bg-background/85 backdrop-blur supports-[backdrop-filter]:bg-background/70">
+          <div className="max-w-7xl mx-auto px-5 md:px-8 py-3 flex items-center justify-between">
+            <p className="text-sm font-semibold tracking-tight">{currentPageLabel}</p>
+            <p className="text-xs text-muted-foreground">PgQueryNarrative</p>
+          </div>
+        </div>
+        <div className="max-w-7xl mx-auto px-5 md:px-8 py-6 md:py-8">
           <Outlet />
         </div>
       </main>

--- a/frontend/src/pages/reports.tsx
+++ b/frontend/src/pages/reports.tsx
@@ -85,7 +85,18 @@ function ReportDetail() {
       {report.chart_suggestions && report.chart_suggestions.length > 0 && (
         <Card>
           <CardHeader><CardTitle className="text-sm">Suggested Charts</CardTitle></CardHeader>
-          <CardContent><div className="flex flex-wrap gap-2">{report.chart_suggestions.map((s, i) => <Badge key={i} variant="outline">{s.label}</Badge>)}</div></CardContent>
+          <CardContent className="space-y-3">
+            <div className="rounded-md border border-primary/20 bg-primary/5 p-3">
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">Recommended</p>
+              <p className="text-sm font-medium mt-1">{report.chart_suggestions[0]?.label}</p>
+              {report.chart_suggestions[0]?.reason && (
+                <p className="text-xs text-muted-foreground mt-1">{report.chart_suggestions[0].reason}</p>
+              )}
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {report.chart_suggestions.map((s, i) => <Badge key={i} variant="outline">{s.label}</Badge>)}
+            </div>
+          </CardContent>
         </Card>
       )}
 


### PR DESCRIPTION
## Linked Issues
Closes #34
Closes #25
Closes #22

## What changed
- pinned Goa CLI install in `Makefile` (`GOA_VERSION=v3.24.1`) for reproducible generation
- added optional LLM chart recommendation pass in report generation to choose one primary chart aligned with narrative headline
- preserved existing rule-based chart suggestions and places LLM recommendation at top
- updated report detail UI to highlight recommended chart and show recommendation reason
- completed remaining layout polish with sticky top page bar and updated content width/padding

## Why
These changes make generation reproducible, improve chart-story alignment, and complete UX polish while keeping rule-based safety and graceful fallbacks.

## Test plan
- [x] `go test ./app/charts ./app/llm`
- [ ] CI checks pass

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Add an LLM-driven primary chart recommendation on top of existing rule-based suggestions and refine the reports UI layout and generation tooling.

New Features:
- Introduce an optional LLM pass to select a primary chart recommendation aligned with the report narrative headline.
- Expose the LLM-selected chart and its explanation as the first suggested chart in report details.

Enhancements:
- Preserve rule-based chart suggestions as the base ordering while allowing an LLM-preferred chart to be promoted or added.
- Update the main layout with a sticky top bar showing the current page label and adjusted content width and padding for reports and other pages.
- Highlight the primary recommended chart in the report detail view, including its rationale, above the full list of chart suggestions.

Build:
- Pin the Goa CLI installation to a specific version in the Makefile for reproducible code generation.