### PR TITLE
docs: update docs and unreleased changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,14 @@ Entries: edit `changelog/unreleased.md` then run `make changelog`.
 
 ### Added
 
+- **Logging (zerolog):** `LOG_LEVEL` (debug, info, warn, error) and `LOG_PRETTY` (colorful console output for local dev). When set, app uses zerolog for leveled, structured logs; request logging uses one message per request (`http request`) with level by status (4xx/5xx → error, /health, /ready, /version → debug, else info). Documented in Configuration – Logging.
 - **Migration 000011:** Set `default_transaction_read_only = on` for the readonly role so the database enforces read-only at session level.
+- **Configurable windows:** `METRICS_MAX_TIMESERIES_PERIODS` (default 24, range 2–120) controls the maximum number of periods included in time-series output ("last N" for charts and period history). Configuration doc now has a "Configurable windows" subsection listing all window-related vars (trend periods, moving avg, max time-series periods, seasonal lag, min periods for seasonality). Settings UI shows max time-series periods when present.
+- **Multiple database connections:** New `GET /api/v1/connections` endpoint plus optional `connection_id` support across run/save/list/report/schema/ask flows. Saved queries and reports now persist `connection_id`.
+
+### Changed
+
+- **Documentation refresh:** Updated configuration, API reference/examples, UI overview, quick start, CLI usage notes, and troubleshooting to reflect multi-connection behavior and current request/response fields.
 
 ### Planned (Release 2)
 
@@ -21,7 +28,7 @@ Additional analytics: further cohort metrics and seasonal adjustments.
 
 ### Planned (Release 2)
 
-Additional analytics: further cohort metrics and seasonal adjustments.
+Additional analytics: further cohort metrics, configurable windows, and seasonal adjustments.
 
 ### Added
 - **Isolation Forest anomaly detection:** `METRICS_ANOMALY_METHOD=isolation_forest` now supported; calculator branches on method and uses Isolation Forest (random trees, median split, anomaly score) when set; z-score remains default

--- a/changelog/unreleased.md
+++ b/changelog/unreleased.md
@@ -5,6 +5,11 @@
 - **Logging (zerolog):** `LOG_LEVEL` (debug, info, warn, error) and `LOG_PRETTY` (colorful console output for local dev). When set, app uses zerolog for leveled, structured logs; request logging uses one message per request (`http request`) with level by status (4xx/5xx → error, /health, /ready, /version → debug, else info). Documented in Configuration – Logging.
 - **Migration 000011:** Set `default_transaction_read_only = on` for the readonly role so the database enforces read-only at session level.
 - **Configurable windows:** `METRICS_MAX_TIMESERIES_PERIODS` (default 24, range 2–120) controls the maximum number of periods included in time-series output ("last N" for charts and period history). Configuration doc now has a "Configurable windows" subsection listing all window-related vars (trend periods, moving avg, max time-series periods, seasonal lag, min periods for seasonality). Settings UI shows max time-series periods when present.
+- **Multiple database connections:** New `GET /api/v1/connections` endpoint plus optional `connection_id` support across run/save/list/report/schema/ask flows. Saved queries and reports now persist `connection_id`.
+
+### Changed
+
+- **Documentation refresh:** Updated configuration, API reference/examples, UI overview, quick start, CLI usage notes, and troubleshooting to reflect multi-connection behavior and current request/response fields.
 
 ### Planned (Release 2)
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -6,17 +6,23 @@ REST API base: `http://localhost:8080/api/v1` (override with [Configuration](../
 
 | Method | Path | Description |
 |--------|------|-------------|
-| POST | `/queries/run` | Body: `{"sql":"...", "limit": 100}`. Run read-only SQL. Returns `columns`, `rows`, `row_count`, `execution_time_ms`, optional `period_comparison`, `chart_suggestions`. |
-| POST | `/queries/saved` | Body: `{"name","sql","tags"}`. Save query. |
-| GET | `/queries/saved` | Query: `limit`, `offset`, `tags`. List saved queries. |
+| POST | `/queries/run` | Body: `{"sql":"...", "limit": 100, "connection_id":"default"}`. `connection_id` optional. Run read-only SQL. Returns `columns`, `rows`, `row_count`, `execution_time_ms`, optional `period_comparison`, `chart_suggestions`. |
+| POST | `/queries/saved` | Body: `{"name","sql","tags","connection_id":"default"}`. `connection_id` optional. Save query. |
+| GET | `/queries/saved` | Query: `limit`, `offset`, `tags`, `connection_id`. List saved queries; optional connection filter. |
 | GET | `/queries/saved/{id}` | Get saved query by ID. |
 | DELETE | `/queries/saved/{id}` | Delete saved query. |
+
+## Connections
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/connections` | Lists configured data connections: `{"items":[{"id","name"}]}`. No secrets returned. |
 
 ## Schema
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/schema` | Allowed schemas, tables, columns. Used by MCP `get_schema`. |
+| GET | `/schema` | Allowed schemas, tables, columns. Query: `connection_id` (optional). Used by MCP `get_schema`. |
 
 ## Suggestions
 
@@ -24,16 +30,16 @@ REST API base: `http://localhost:8080/api/v1` (override with [Configuration](../
 |--------|------|-------------|
 | GET | `/suggestions/queries` | Query: `intent`, `limit` (default 5). Suggested SQL (curated + saved-query match). |
 | GET | `/suggestions/similar` | Query: `text` (required), `limit` (default 5). Saved queries semantically similar to text (embedding-based). Requires [embeddings](../reference/semantic-search-pgvector.md) enabled. |
-| POST | `/suggestions/ask` | Body: `{"question":"..."}`. Natural language → SQL → run → narrative report. Requires [LLM](../getting-started/llm-setup.md). |
+| POST | `/suggestions/ask` | Body: `{"question":"...", "connection_id":"default"}`. `connection_id` optional. Natural language → SQL → run → narrative report. Requires [LLM](../getting-started/llm-setup.md). |
 | POST | `/suggestions/explain` | Body: `{"sql":"..."}`. Plain-English explanation of SQL. Requires [LLM](../getting-started/llm-setup.md). |
 
 ## Reports
 
 | Method | Path | Description |
 |--------|------|-------------|
-| POST | `/reports/generate` | Body: `{"sql":"...", "saved_query_id": "uuid"}`. Generate report (requires [LLM](../getting-started/llm-setup.md)). Returns `narrative`, `metrics`. |
+| POST | `/reports/generate` | Body: `{"sql":"...", "saved_query_id":"uuid", "connection_id":"default"}`. `connection_id` optional. Generate report (requires [LLM](../getting-started/llm-setup.md)). Returns `narrative`, `metrics`. |
 | GET | `/reports/{id}` | Get report. Metrics: `time_series`, `correlations`, `cohorts` (when [cohort shape](../configuration.md#cohort-analysis) present), `data_quality`, `perf_suggestions`, etc. |
-| GET | `/reports` | Query: `limit`, `offset`, `saved_query_id`. List reports. |
+| GET | `/reports` | Query: `limit`, `offset`, `saved_query_id`, `connection_id`. List reports; optional connection filter. |
 
 ## Errors
 

--- a/docs/api/examples.md
+++ b/docs/api/examples.md
@@ -5,9 +5,23 @@ Base URL: `http://localhost:8080` (or set port via [Configuration](../configurat
 **Example — run query:**
 
 ```bash
-curl -s -X POST http://localhost:8080/api/v1/queries/run -H "Content-Type: application/json" -d '{"sql":"SELECT product_category, SUM(total_amount) AS total FROM demo.sales GROUP BY product_category", "limit":10}'
+curl -s -X POST http://localhost:8080/api/v1/queries/run \
+  -H "Content-Type: application/json" \
+  -d '{"sql":"SELECT product_category, SUM(total_amount) AS total FROM demo.sales GROUP BY product_category","limit":10,"connection_id":"default"}'
 ```
 
 Response: `columns`, `rows`, `row_count`, `execution_time_ms`, optional `chart_suggestions`, `period_comparison` (when result has a time column and measures).
+
+**Example — list connections:**
+
+```bash
+curl -s http://localhost:8080/api/v1/connections
+```
+
+Response:
+
+```json
+{"items":[{"id":"default","name":"Default"},{"id":"prod","name":"Production"}]}
+```
 
 **See also:** [API reference](README.md) · [Configuration](../configuration.md) · [Documentation index](../README.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,6 +51,48 @@ PgQueryNarrative is configured via **environment variables** only. Sensible defa
 | `DATABASE_MAX_CONNECTIONS` | `10` | Max connection pool size. |
 | `QUERY_TIMEOUT` | `30s` | Query execution timeout. |
 | `DATABASE_ALLOWED_SCHEMAS` | `public,demo` | Comma-separated schemas queries may access. Use your own schemas here (e.g. `public` or `public,analytics`). |
+| `DATABASE_DEFAULT_CONNECTION_ID` | `default` | Default data connection ID used when `connection_id` is omitted in API/UI/MCP requests. |
+| `DATABASE_CONNECTIONS_JSON` | (empty) | Optional JSON array of additional read-only data connections. Each item supports: `id`, `name`, `host`, `port`, `database`, `readOnlyUser`, `readOnlyPassword`, `sslMode`, `queryTimeout`, `allowedSchemas`. |
+
+### Multiple database connections {#multiple-database-connections}
+
+PgQueryNarrative supports multiple read-only data connections for query/report/schema flows. App tables (`saved_queries`, `reports`, audit, embeddings) stay in the single app DB configured by `DATABASE_*`.
+
+- If `DATABASE_CONNECTIONS_JSON` is empty, one `default` connection is derived from `DATABASE_HOST`, `DATABASE_PORT`, `DATABASE_NAME`, and read-only credentials.
+- If `DATABASE_CONNECTIONS_JSON` is set, those connections are added on top of `default`.
+- Requests may pass `connection_id`; when omitted or unknown, server falls back to `DATABASE_DEFAULT_CONNECTION_ID`.
+
+Example:
+
+```bash
+export DATABASE_DEFAULT_CONNECTION_ID=default
+export DATABASE_CONNECTIONS_JSON='[
+  {
+    "id": "staging",
+    "name": "Staging",
+    "host": "staging-db.internal",
+    "port": 5432,
+    "database": "analytics_staging",
+    "readOnlyUser": "analytics_ro",
+    "readOnlyPassword": "secret",
+    "sslMode": "require",
+    "queryTimeout": "30s",
+    "allowedSchemas": ["public","analytics"]
+  },
+  {
+    "id": "prod",
+    "name": "Production",
+    "host": "prod-db.internal",
+    "port": 5432,
+    "database": "analytics_prod",
+    "readOnlyUser": "analytics_ro",
+    "readOnlyPassword": "secret",
+    "sslMode": "require",
+    "queryTimeout": "30s",
+    "allowedSchemas": ["public","analytics"]
+  }
+]'
+```
 
 ---
 
@@ -95,7 +137,7 @@ For [LLM setup – MCP](getting-started/llm-setup.md#mcp-claude-desktop--cursor)
    }
    ```
    If the app is not at http://localhost:8080, set `"env": { "PGQUERYNARRATIVE_URL": "http://localhost:PORT" }`. If the app has auth enabled (`SECURITY_AUTH_ENABLED=true`), set `"env": { "PGQUERYNARRATIVE_API_KEY": "your-secret-key" }` (same value as `SECURITY_API_KEY`). See `config/mcp-example.json`.
-4. Restart the client. Available tools: `run_query`, `generate_report`, `list_saved_queries`, `get_report`, `list_reports`, `get_schema`, `get_context`, `suggest_queries`, `list_schemas`, `ask_question`, `explain_sql`. See [How to use MCP tools](getting-started/llm-setup.md#how-to-use-mcp-tools-in-cursor--claude) below.
+4. Restart the client. Available tools: `run_query`, `generate_report`, `list_saved_queries`, `get_report`, `list_reports`, `get_schema`, `list_connections`, `get_context`, `suggest_queries`, `list_schemas`, `ask_question`, `explain_sql`. For multi-connection setups, these tools accept optional `connection_id` on relevant calls.
 
 ---
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -17,6 +17,8 @@ make start-docker
 
 Uses root [docker-compose.yml](../../docker-compose.yml) (PostgreSQL + app). App at **http://localhost:8080**. For production image and Compose: [Deployment](../reference/deployment.md).
 
+For multi-database setups, configure `DATABASE_CONNECTIONS_JSON` and `DATABASE_DEFAULT_CONNECTION_ID` before starting (see [Configuration – Multiple database connections](../configuration.md#multiple-database-connections)).
+
 ## Local PostgreSQL
 
 ```bash

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -21,6 +21,7 @@ Common issues and fixes. For deployment and monitoring see [Deployment](deployme
 |-------|----------|
 | **PostgreSQL connection refused** | **Docker:** [Quick start](../getting-started/quickstart.md) – `make start-docker`. **Local:** start Postgres (e.g. `brew services start postgresql@18`), then `make start-local`. |
 | **Role does not exist / permission denied** | Run `make db-init` then `make migrate`, or `make start-local` once (see [Installation](../getting-started/installation.md)). If `demo.sales` denied: grant SELECT to `pgquerynarrative_readonly` on the table. |
+| **Unexpected results from wrong data source** | Set `connection_id` explicitly in API/MCP calls. If omitted or unknown, server falls back to `DATABASE_DEFAULT_CONNECTION_ID` (see [Configuration – Multiple database connections](../configuration.md#multiple-database-connections)). |
 
 ---
 

--- a/docs/ui-overview.md
+++ b/docs/ui-overview.md
@@ -5,6 +5,7 @@ The web UI is a React SPA (Vite, Tailwind CSS, shadcn/ui) built from [`frontend/
 - **Query editor** — Schema browser, SQL suggestions, and **Ask** (natural language → SQL + report).
 - **Saved queries** — List, create, edit, delete; run and generate reports from a saved query.
 - **Reports** — List reports; open a report to view narrative, metrics (time-series, forecast, correlations, cohorts when applicable), and export (HTML/PDF).
+- **Connection-aware workflows** — Connection picker in Query Runner/Ask; schema browser refreshes by selected connection; Saved Queries and Reports show `connection_id` badges and support filtering by connection.
 
 Read-only analytics settings (e.g. trend threshold, anomaly sigma) are shown in **Settings → Analytics**; values come from [Configuration](configuration.md#metrics).
 

--- a/docs/usage/cli-usage.md
+++ b/docs/usage/cli-usage.md
@@ -2,6 +2,13 @@
 
 Command-line access to the PgQueryNarrative API. The app must be running ([Quick start](../getting-started/quickstart.md): `make start-docker` or `make start-local`). The CLI runs in a container (Docker) or on the host (local binary). It calls the same [REST API](../api/README.md) used by the web UI.
 
+## Multi-connection note
+
+The legacy `make cli` wrapper does not yet expose a dedicated `--connection-id` flag. For connection-specific automation, use:
+
+- REST API calls with `connection_id` (see [API examples](../api/examples.md)), or
+- MCP tools (`run_query`, `generate_report`, `list_saved_queries`, `list_reports`, `get_schema`, `list_schemas`, `ask_question`) with optional `connection_id`.
+
 ## Commands
 
 | Command | Description | API equivalent |


### PR DESCRIPTION
## Summary
- refresh configuration docs with multi-connection settings (`DATABASE_CONNECTIONS_JSON`, default connection behavior, and examples)
- update API/docs/UI/quickstart/troubleshooting to include `connection_id` usage and `GET /api/v1/connections`
- update unreleased changelog entries to reflect multi-connection support and documentation updates

## Test plan
- [x] `make changelog`
- [x] docs links and examples reviewed for updated fields/endpoints

Closes #24
Closes #12

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Document multi-database connection support and related API/UI behavior, and update the unreleased changelog accordingly.

New Features:
- Add configuration docs for multiple read-only database connections, including `DATABASE_CONNECTIONS_JSON` and `DATABASE_DEFAULT_CONNECTION_ID` usage and examples.
- Document the new `GET /api/v1/connections` endpoint and connection-aware behavior across query, schema, suggestions, and reports APIs.

Enhancements:
- Update API docs, examples, UI overview, quickstart, CLI usage notes, and troubleshooting to describe optional `connection_id` parameters and multi-connection workflows.
- Refresh unreleased changelog entries to capture multi-connection support, configurable windows, and other recent documentation changes.