### PR TITLE
fix(queryrunner): bound result slice capacity to clear CodeQL alert

### DIFF
--- a/app/queryrunner/limits.go
+++ b/app/queryrunner/limits.go
@@ -1,0 +1,19 @@
+package queryrunner
+
+// DefaultMaxRows is the row cap when configuration is missing or invalid.
+const DefaultMaxRows = 1000
+
+// AbsoluteMaxRows is the hard ceiling for result slice capacity and runner config.
+// It bounds memory allocation even if callers pass an oversized limit or maxRows.
+const AbsoluteMaxRows = 10000
+
+// capRowCount returns a safe slice capacity in [1, AbsoluteMaxRows].
+func capRowCount(n int) int {
+	if n <= 0 {
+		return DefaultMaxRows
+	}
+	if n > AbsoluteMaxRows {
+		return AbsoluteMaxRows
+	}
+	return n
+}

--- a/app/queryrunner/limits_test.go
+++ b/app/queryrunner/limits_test.go
@@ -1,0 +1,25 @@
+package queryrunner
+
+import "testing"
+
+func TestCapRowCount(t *testing.T) {
+	tests := []struct {
+		name string
+		in   int
+		want int
+	}{
+		{"zero uses default", 0, DefaultMaxRows},
+		{"negative uses default", -1, DefaultMaxRows},
+		{"within range", 500, 500},
+		{"at ceiling", AbsoluteMaxRows, AbsoluteMaxRows},
+		{"above ceiling", AbsoluteMaxRows + 1, AbsoluteMaxRows},
+		{"max int", 1<<31 - 1, AbsoluteMaxRows},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := capRowCount(tt.in); got != tt.want {
+				t.Fatalf("capRowCount(%d) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/app/queryrunner/runner.go
+++ b/app/queryrunner/runner.go
@@ -50,7 +50,7 @@ func NewRunner(pool *pgxpool.Pool, validator *Validator, maxRows int, timeout ti
 	r := &Runner{
 		pool:       pool,
 		validator:  validator,
-		maxRows:    maxRows,
+		maxRows:    capRowCount(maxRows),
 		queryLimit: timeout,
 	}
 	for _, opt := range opts {
@@ -71,6 +71,7 @@ func (r *Runner) Run(ctx context.Context, sql string, limit int) (*Result, error
 	if limit <= 0 || limit > r.maxRows {
 		limit = r.maxRows
 	}
+	rowCap := capRowCount(limit)
 
 	queryCtx, cancel := context.WithTimeout(ctx, r.queryLimit)
 	defer cancel()
@@ -78,7 +79,7 @@ func (r *Runner) Run(ctx context.Context, sql string, limit int) (*Result, error
 	wrappedSQL := fmt.Sprintf("SELECT * FROM (%s) AS pgqn_sub LIMIT $1", cleanedSQL)
 
 	start := time.Now()
-	rows, err := r.pool.Query(queryCtx, wrappedSQL, limit)
+	rows, err := r.pool.Query(queryCtx, wrappedSQL, rowCap)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) || errors.Is(queryCtx.Err(), context.DeadlineExceeded) {
 			return nil, fmt.Errorf("%s: query exceeded timeout of %v", apperrors.ErrQueryTimeout, r.queryLimit)
@@ -104,7 +105,7 @@ func (r *Runner) Run(ctx context.Context, sql string, limit int) (*Result, error
 		}
 	}
 
-	resultRows := make([][]interface{}, 0, limit)
+	resultRows := make([][]interface{}, 0, rowCap)
 	for rows.Next() {
 		values, err := rows.Values()
 		if err != nil {
@@ -125,8 +126,8 @@ func (r *Runner) Run(ctx context.Context, sql string, limit int) (*Result, error
 		Rows:             resultRows,
 		RowCount:         len(resultRows),
 		ExecutionTimeMs:  executionTime.Milliseconds(),
-		RowLimitApplied:  limit,
-		OriginalRowLimit: limit,
+		RowLimitApplied:  rowCap,
+		OriginalRowLimit: rowCap,
 	}, nil
 }
 

--- a/pkg/narrative/client.go
+++ b/pkg/narrative/client.go
@@ -71,7 +71,7 @@ func NewClient(ctx context.Context, cfg Config) (*Client, error) {
 	}
 	maxRows := cfg.MaxRowsPerQuery
 	if maxRows <= 0 {
-		maxRows = 1000
+		maxRows = queryrunner.DefaultMaxRows
 	}
 
 	validator := queryrunner.NewValidator(allowedSchemas, maxQueryLength)


### PR DESCRIPTION
## Summary
- Add `capRowCount` with hard ceiling `AbsoluteMaxRows` (10,000)
- Clamp runner config in `NewRunner` and slice capacity in `Run()`
- Clears CodeQL alert: slice memory allocation with excessive size value

Closes #54

## Test plan
- [x] `go test ./app/queryrunner/...`
- [x] `go test ./test/unit/app/queryrunner/...`
- [ ] CodeQL re-scan clears alert #1

## Summary by Sourcery

Bound query runner row limits to a safe maximum to prevent excessive slice allocations and clear the CodeQL alert.

Bug Fixes:
- Clamp query execution limits and result slice capacity to a bounded maximum to avoid excessive memory allocation and address the CodeQL warning.

Enhancements:
- Introduce DefaultMaxRows and AbsoluteMaxRows configuration for query results, and reuse them from the narrative client for consistent limits.

Tests:
- Add unit tests for capRowCount to verify defaulting, upper bound enforcement, and handling of extreme input values.