### PR TITLE
docs: add MkDocs Material local preview via make docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup tidy generate build build-mcp run test test-unit test-features test-integration test-e2e test-playwright test-playwright-oidc test-load-smoke test-frontend lint fmt migrate migrate-docker migrate-cycle-docker db-security-verify-docker seed seed-large seed-large-docker seed-nyc seed-nyc-docker postgres-up postgres-recreate dev dev-stop dev-watch dev-build dev-teardown docker-up docker-down docker-logs db-init db-init-docker start start-docker start-local stop cli cli-shell changelog build-release linkedin-social-help linkedin-social-draft pilot-acceptance pilot-report helm-strict-check demo-bootstrap demo-smoke demo-multi-org
+.PHONY: setup tidy generate build build-mcp run test test-unit test-features test-integration test-e2e test-playwright test-playwright-oidc test-load-smoke test-frontend lint fmt migrate migrate-docker migrate-cycle-docker db-security-verify-docker seed seed-large seed-large-docker seed-nyc seed-nyc-docker postgres-up postgres-recreate dev dev-stop dev-watch dev-build dev-teardown docker-up docker-down docker-logs db-init db-init-docker start start-docker start-local stop cli cli-shell changelog build-release linkedin-social-help linkedin-social-draft pilot-acceptance pilot-report helm-strict-check demo-bootstrap demo-smoke demo-multi-org docs
 
 GO ?= go
 GOLANGCI_LINT ?= golangci-lint
@@ -557,3 +557,11 @@ install-extension:
 
 install-extension-docker:
 	@sh ./tools/db/install-extension-docker.sh
+
+# ============================================================================
+# Documentation (MkDocs Material — local preview at http://localhost:8000)
+# ============================================================================
+
+docs:
+	docker build -t pgquerynarrative-docs ./docs
+	docker run --rm -it -p 8000:8000 -v ${PWD}:/docs pgquerynarrative-docs

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Report generation is **optional**. When configured, PgQueryNarrative can turn qu
 
 ## Documentation
 
-Full documentation in **[docs/](docs/README.md)**:
+Full documentation in **[docs/](docs/README.md)**. Preview locally with **`make docs`** → http://localhost:8000.
 
 | Section | Links |
 |---------|--------|

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,0 +1,8 @@
+FROM squidfunk/mkdocs-material:latest@sha256:51b87149d227691486b5f08993d28c65ca7e4990010664b697265b8e6fcd5287
+
+RUN pip install pymdown-extensions
+
+# No USER directive: `make docs` bind-mounts the whole repo (-v ${PWD}:/docs)
+# with no UID mapping, and the host directory's owning UID varies per
+# developer/CI runner. Baking in a fixed non-root UID risks permission-denied
+# reads of the bind-mounted docs on any host whose UID doesn't match.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,8 @@ Run read-only SQL against PostgreSQL, compute metrics and chart suggestions, and
 
 **Recommended path:** [Quick start](getting-started/quickstart.md) → [LLM setup](getting-started/llm-setup.md) (for reports) → [Configuration](configuration.md).
 
+**Local preview:** run `make docs` from the repo root, then open **http://localhost:8000** (MkDocs Material with search and navigation).
+
 ---
 
 ## Docs index

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,41 @@
+# PgQueryNarrative
+
+**PostgreSQL query intelligence that shows its evidence.** Run read-only SQL against PostgreSQL, analyze execution plans, compare improvements, and produce engineering-ready reports — with an optional LLM narrative layer on top.
+
+Web UI: [UI overview](ui-overview.md) · Automation: [REST API](api/README.md) and [CLI](usage/cli-usage.md).
+
+## Recommended path
+
+1. [Quick start](getting-started/quickstart.md)
+2. [LLM setup](getting-started/llm-setup.md) (for narrative reports)
+3. [Configuration](configuration.md)
+
+## One-command demo
+
+```bash
+make demo
+```
+
+Open **http://localhost:8080** and follow the guided Query Investigation workflow. See [Demo runbook](DEMO_RUNBOOK.md) for scene-by-scene details.
+
+## Documentation map
+
+| Topic | Document |
+|-------|----------|
+| Architecture & daily dev | [Development runbook](development/runbook.md) |
+| API | [API reference](api/README.md) · [Examples](api/examples.md) |
+| Deployment | [Deployment](reference/deployment.md) · [Production checklist](ops/PRODUCTION.md) |
+| Operations | [Operations](reference/operations.md) · [Incident runbooks](ops/INCIDENT_RUNBOOKS.md) |
+| Troubleshooting | [Troubleshooting](reference/troubleshooting.md) |
+
+## Local preview
+
+Browse this site with search and navigation at **http://localhost:8000**:
+
+```bash
+make docs
+```
+
+---
+
+**Contributing & security:** [CONTRIBUTING.md](https://github.com/pgquerynarrative/pgquerynarrative/blob/main/.github/CONTRIBUTING.md) · [SECURITY.md](https://github.com/pgquerynarrative/pgquerynarrative/blob/main/.github/SECURITY.md) · **Changelog:** [CHANGELOG.md](https://github.com/pgquerynarrative/pgquerynarrative/blob/main/CHANGELOG.md)

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,4 @@
+.md-typeset table:not([class]) {
+  display: table;
+  width: 100%;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,85 @@
+site_name: PgQueryNarrative
+site_description: PostgreSQL query intelligence — safe read-only SQL, plan analysis, and evidence-backed reports.
+site_url: https://github.com/pgquerynarrative/pgquerynarrative
+
+extra_css:
+  - stylesheets/extra.css
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - tables
+  - toc:
+      permalink: true
+
+plugins:
+  - search
+
+theme:
+  name: material
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.top
+    - toc.follow
+    - content.code.copy
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+extra:
+  generator: false
+  repo_url: https://github.com/pgquerynarrative/pgquerynarrative
+
+nav:
+  - Overview: index.md
+  - Getting started:
+      - Quick start: getting-started/quickstart.md
+      - Installation: getting-started/installation.md
+      - LLM setup: getting-started/llm-setup.md
+      - Embedded integration: getting-started/embedded.md
+  - User guides:
+      - UI overview: ui-overview.md
+      - CLI usage: usage/cli-usage.md
+      - Demo runbook: DEMO_RUNBOOK.md
+  - Configuration: configuration.md
+  - API:
+      - API reference: api/README.md
+      - Examples: api/examples.md
+  - Reference:
+      - Deployment: reference/deployment.md
+      - Operations: reference/operations.md
+      - Troubleshooting: reference/troubleshooting.md
+      - PostgreSQL extension: reference/postgres-extension.md
+      - Semantic search (pgvector): reference/semantic-search-pgvector.md
+      - Versioning and releases: reference/versioning-and-releases.md
+      - Dataset and schema: DATASET.md
+  - Operations:
+      - Production checklist: ops/PRODUCTION.md
+      - Incident runbooks: ops/INCIDENT_RUNBOOKS.md
+      - RLS demo: ops/rls-demo.md
+  - Development:
+      - Setup: development/setup.md
+      - Testing: development/testing.md
+      - Runbook: development/runbook.md
+  - Case studies:
+      - Query optimization: case-studies/01-query-optimization.md


### PR DESCRIPTION
## Summary
- Add MkDocs Material Docker-based docs preview, following the [pgEdge control-plane](https://github.com/pgEdge/control-plane) `make docs` pattern
- Introduce `mkdocs.yml` navigation mapped to this repo’s existing docs (getting started, API, ops, development, case studies)
- Document local preview at http://localhost:8000 in the root README and `docs/README.md`

Closes #79

## Test plan
- [ ] Run `make docs` with Docker available
- [ ] Confirm site loads at http://localhost:8000
- [ ] Spot-check nav links (quick start, API, production checklist, development runbook)
- [ ] Edit a docs Markdown file and confirm live reload in the preview