### PR TITLE
docs: restructure README and investigation-first docs hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 <h1 align="center">PgQueryNarrative</h1>
 
 <p align="center">
-<strong>PostgreSQL Query Intelligence That Shows Its Evidence</strong><br>
-Find expensive queries, investigate execution plans, compare improvements,<br>
-and produce engineering-ready reports.
+<strong>PostgreSQL query intelligence that shows its evidence</strong><br>
+Investigate expensive queries, compare rewrites with plan proof,<br>
+and ship engineering-ready reports.
 </p>
 
 <p align="center">
@@ -21,9 +21,10 @@ and produce engineering-ready reports.
 </p>
 
 <p align="center">
-  <a href="#quick-start"><strong>Try the guided demo</strong></a> ·
-  <a href="docs/README.md">Documentation</a> ·
-  <a href="docs/development/runbook.md">Architecture</a> ·
+  <a href="#try-it-5-minutes"><strong>Try the demo</strong></a> ·
+  <a href="docs/getting-started/connect-postgres.md">Connect your Postgres</a> ·
+  <a href="docs/ops/PRODUCTION.md#start-here">Ship to production</a> ·
+  <a href="docs/index.md">Documentation</a> ·
   <a href=".github/SECURITY.md">Security</a>
 </p>
 
@@ -35,163 +36,132 @@ and produce engineering-ready reports.
 
 ---
 
-## Overview
+## What it is
 
-PgQueryNarrative is a **PostgreSQL investigation workbench** that turns workload statistics, SQL, query results, and execution plans into evidence-backed explanations and engineering-ready reports.
+PgQueryNarrative is a **PostgreSQL investigation workbench**. The flagship loop is:
 
-The flagship **Query Investigation** workflow guides you from expensive query → plan evidence → candidate comparison → verified report. The React workbench includes an interactive plan tree, before/after plan comparison, regression inbox, and a Security & Trust page that makes hardening visible.
+**expensive query → plan findings → candidate rewrite → measured compare → engineering report**
 
-The optional LLM narrative layer sits on top — the core value is safe SQL execution and plan analysis, not the LLM.
+Safe read-only SQL and plan analysis are the core. An optional LLM can narrate; it is not required for investigation reports. Start with [Concepts](docs/concepts.md) if you want the vocabulary (evidence, EXPLAIN vs ANALYZE, what compare proves).
 
-## Quick start
+## Choose your path
 
-**One-command guided demo** (PostgreSQL + app + small seed; ready in ~2 minutes):
+| You want to… | Start here |
+|--------------|------------|
+| **Try it in ~5 minutes** | [Try it](#try-it-5-minutes) — `make demo` + guided Investigate |
+| **Connect your PostgreSQL** | [Connect your Postgres](docs/getting-started/connect-postgres.md) — readonly role + schema allowlist |
+| **Ship to production** | [Production — start here](docs/ops/PRODUCTION.md#start-here) — StrictMode, replicas, checklists |
+| **Understand trust & scope** | [Trust model](docs/trust-model.md) — what the app will and will not do |
+
+---
+
+## Try it (5 minutes)
+
+Requires Docker. Starts Postgres + app + small seed (~2 minutes):
 
 ```bash
 make demo
 ```
 
-Open **http://localhost:8080** and use the guided path:
+Open **http://localhost:8080**:
 
-1. Click **Start guided demo** or open **Investigate**
+1. **Start guided demo** or open **Investigate**
 2. Choose **Slow dashboard query**
-3. Review the bad predicate: `DATE_TRUNC('month', date) = DATE '2025-01-01'` (blocks partition pruning)
-4. Click **Compare plans** to test the range-predicate rewrite (`date >= … AND date < …`)
-5. Click **Generate report** to open the engineering investigation report
+3. Review the finding (e.g. `DATE_TRUNC` blocking partition pruning)
+4. **Compare plans** on the range-predicate rewrite
+5. **Generate report**
 
-For README-quality timings and partition counts, use the 10M-row seed:
-
-```bash
-make demo-bootstrap   # or: make demo && make seed-large-docker
-```
-
-The guided investigation report is evidence-backed and works without the LLM.
-`make demo` also starts **Ollama in Docker** and pulls `llama3.2` so the workbench
-**Ask in natural language** flow works out of the box (first run may take a few
-minutes while the model downloads).
-
-**Docker-first** (full control):
+For README-scale partition counts (50→1 on ~10M rows):
 
 ```bash
-# 1. Start Postgres
-make postgres-up
-
-# 2. Apply migrations (includes monthly range partitions on demo.sales)
-make migrate-docker
-
-# 3. Start the full stack (app + Postgres; uses small seed by default)
-make start-docker
+make demo-bootstrap
 ```
 
-**Advanced benchmark** (~10M rows for partition pruning and optimization work; several minutes):
+`make demo` also starts **Ollama** and pulls `llama3.2` so **Ask in natural language** works locally (first run may download the model). Investigation still works if you skip the LLM.
 
-```bash
-make seed-large-docker
-```
+More detail: [Quick start](docs/getting-started/quickstart.md) · [Demo runbook](docs/DEMO_RUNBOOK.md)
 
-See [docs/DATASET.md](docs/DATASET.md) for schema layout, measured sizes, and pruning evidence.
+---
 
-Open **http://localhost:8080** for the web UI, or call the API directly ([API examples](docs/api/examples.md)):
+## Trust model (short)
 
-```bash
-# Run a read-only query
-curl -X POST http://localhost:8080/api/v1/queries/run \
-  -H "Content-Type: application/json" \
-  -d '{"sql": "SELECT product_category, SUM(total_amount) AS total FROM demo.sales GROUP BY product_category", "limit": 10}'
+- User SQL runs as a **dedicated read-only role**, not the app migration user
+- Schemas are **allowlisted** (`DATABASE_ALLOWED_SCHEMAS`, default `demo`)
+- **Writes and DDL are blocked** in the query validator
+- Cloud LLM row egress is **off unless you explicitly enable it**
 
-# Analyze the query plan (seq scans, cost, index suggestions)
-curl -X POST http://localhost:8080/api/v1/queries/explain \
-  -H "Content-Type: application/json" \
-  -d '{"sql": "SELECT product_category, SUM(total_amount) FROM demo.sales WHERE region = '\''North'\'' GROUP BY product_category"}'
-```
+Full write-up: [Trust model](docs/trust-model.md)
 
-**Local PostgreSQL** (app on host; Postgres must already be running):
+---
 
-```bash
-make start-local
-```
+## Capabilities
 
-See [Configuration](docs/configuration.md) for all environment variables.
+| Area | What you get |
+|------|----------------|
+| **Query Investigation** | Findings from EXPLAIN, candidate compare, engineering report |
+| **Secure read-only access** | Readonly pool, statement limits, timeouts, schema allowlist |
+| **Plan analysis** | Seq-scan / cost findings; optional `EXPLAIN ANALYZE` when enabled |
+| **Workbench** | Plan tree, compare table, regression inbox, Security & Trust page |
+| **Scale demo** | Partitioned `demo.sales`; 10M-row seed — [Dataset](docs/DATASET.md) |
 
-## Postgres capabilities
+Optional narratives: [LLM setup](docs/getting-started/llm-setup.md) · library embed: [Embedded integration](docs/getting-started/embedded.md)
 
-| Area | What PgQueryNarrative does |
-|------|----------------------------|
-| **Secure read-only access** | Queries run on a dedicated `pgquerynarrative_readonly` role; results wrapped in `SELECT * FROM (<sql>) LIMIT $1`; per-query timeout (30s default). |
-| **Query validation** | Single-statement enforcement, `demo` schema allowlist, write/DDL blocklist. |
-| **EXPLAIN integration** | `POST /api/v1/queries/explain` runs `EXPLAIN (FORMAT JSON [, ANALYZE, BUFFERS])`, parses the plan tree, flags seq scans and high-cost nodes, suggests indexes. |
-| **Scale & partitioning** | `demo.sales` is range-partitioned by month (~49 partitions); reproducible 10M-row seed via `make seed-large-docker`. [docs/DATASET.md](docs/DATASET.md) documents sizes and partition-pruning evidence. |
-| **Analytics in SQL** | Period-over-period comparison via window functions (`LAG`, `DATE_TRUNC`); metrics and chart suggestions from result shape. |
-
-## Optional: AI narrative layer
-
-Report generation is **optional**. When configured, PgQueryNarrative can turn query results into business narratives using your choice of LLM (Ollama, OpenAI, Claude, Gemini, Groq). This sits on top of the Postgres query layer — the core value is safe SQL execution and plan analysis, not the LLM.
-
-- [LLM setup](docs/getting-started/llm-setup.md) — provider configuration
-- [Embedded integration](docs/getting-started/embedded.md) — use as a library via `pkg/narrative/`
-
-## Requirements
-
-- **Docker** (for `make start-docker` and the Docker-first workflow above), or **PostgreSQL 16+** and **Go 1.25+** (for `make start-local` and building).
-- For the full web UI from source: **Node.js** and **npm** (to build the [frontend](frontend/)).
+---
 
 ## Commands
 
 | Action | Command |
-|--------|--------|
-| **Guided demo (recommended)** | `make demo` |
+|--------|---------|
+| **Guided demo** | `make demo` |
 | Guided demo + 10M-row seed | `make demo-bootstrap` |
-| Record README demo GIF (requires 10M seed) | `make demo-gif` |
-| Bootstrap 10M seed + record GIF | `make demo-gif-credible` |
-| Start Postgres only | `make postgres-up` |
+| Start / stop stack | `make start-docker` / `make stop` |
 | Migrate (Docker) | `make migrate-docker` |
 | Seed 10M rows (Docker) | `make seed-large-docker` |
-| Start full stack (Docker) | `make start-docker` |
-| Start (local) | `make start-local` |
-| Stop | `make stop` |
-| Build | `make build` (frontend + server) |
-| Test | `make test` |
+| Local app (Postgres already up) | `make start-local` |
+| Build / test | `make build` / `make test` |
 | CLI | `make cli CMD='query "SELECT * FROM demo.sales LIMIT 5"'` |
+
+Maintainer GIF capture lives in the [Demo runbook](docs/DEMO_RUNBOOK.md#readme-gif-capture).
+
+---
 
 ## Project structure
 
 | Path | Purpose |
 |------|---------|
-| [`cmd/server`](cmd/server) | Application entrypoint; serves API, health/ready, web export, React SPA |
-| [`app/`](app/) | Core logic: config, DB, [query runner](app/queryrunner), [metrics](app/metrics), [LLM](app/llm), [narrative](app/story), [service](app/service) |
-| [`api/design/`](api/design/) | [Goa](https://goa.design/) API design; generated code in `api/gen/` and root `gen/` |
-| [`frontend/`](frontend/) | React SPA (Vite, Tailwind CSS, shadcn/ui); built to `frontend/dist`, served by Go at `/` |
-| [`web/`](web/) | Server-side web handlers (report export: [HTML](web/handlers.go), [PDF](web/pdf.go)) |
-| [`pkg/narrative/`](pkg/narrative/) | Library client and middleware for [embedded integration](docs/getting-started/embedded.md) |
-| [`docs/`](docs/README.md) | Documentation |
-| [`test/unit/`](test/unit/), [`test/integration/`](test/integration/), [`test/e2e/`](test/e2e/) | Tests |
-| [`changelog/`](changelog/) | Release history |
+| [`cmd/server`](cmd/server) | API, health/ready, SPA |
+| [`app/`](app/) | Config, DB, query runner, investigations, LLM, reports |
+| [`api/design/`](api/design/) | Goa API design → `api/gen/` |
+| [`frontend/`](frontend/) | React workbench |
+| [`docs/`](docs/index.md) | Documentation (preview: `make docs`) |
+| [`pkg/narrative/`](pkg/narrative/) | Embeddable client |
+
+---
 
 ## Documentation
 
-Full documentation in **[docs/](docs/README.md)**. Preview locally with **`make docs`** → http://localhost:8000.
+Preview: **`make docs`** → http://localhost:8000
 
 | Section | Links |
 |---------|--------|
-| **Getting started** | [Installation](docs/getting-started/installation.md) · [Quick start](docs/getting-started/quickstart.md) · [LLM setup](docs/getting-started/llm-setup.md) · [Embedded integration](docs/getting-started/embedded.md) |
-| **User guides** | [Configuration](docs/configuration.md) · [UI overview](docs/ui-overview.md) · [CLI usage](docs/usage/cli-usage.md) |
+| **Start here** | [Docs overview](docs/index.md) · [Concepts](docs/concepts.md) · [Trust model](docs/trust-model.md) |
+| **Getting started** | [Quick start](docs/getting-started/quickstart.md) · [Installation](docs/getting-started/installation.md) · [Connect Postgres](docs/getting-started/connect-postgres.md) · [LLM setup](docs/getting-started/llm-setup.md) |
+| **Product** | [UI overview](docs/ui-overview.md) · [Demo runbook](docs/DEMO_RUNBOOK.md) · [Configuration](docs/configuration.md) |
 | **API** | [Reference](docs/api/README.md) · [Examples](docs/api/examples.md) |
-| **Reference** | [Deployment](docs/reference/deployment.md) · [Operations](docs/reference/operations.md) · [Troubleshooting](docs/reference/troubleshooting.md) · [PostgreSQL extension](docs/reference/postgres-extension.md) · [Semantic search (pgvector)](docs/reference/semantic-search-pgvector.md) |
-| **Development** | [Setup](docs/development/setup.md) · [Testing](docs/development/testing.md) · [Runbook](docs/development/runbook.md) |
-| **Dataset & case studies** | [10M-row benchmark & partition pruning](docs/DATASET.md) · [Query optimization case study](docs/case-studies/01-query-optimization.md) |
-| **Operations** | [Production ops](docs/ops/PRODUCTION.md) · [RLS demo](docs/ops/rls-demo.md) |
+| **Ops** | [Deployment](docs/reference/deployment.md) · [Production](docs/ops/PRODUCTION.md) · [Troubleshooting](docs/reference/troubleshooting.md) |
+| **Develop** | [Setup](docs/development/setup.md) · [Testing](docs/development/testing.md) · [Dev runbook](docs/development/runbook.md) |
+| **Evidence** | [Dataset](docs/DATASET.md) · [Case study](docs/case-studies/01-query-optimization.md) |
 
-**Contributing & security:** [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md) · [.github/SECURITY.md](.github/SECURITY.md). **Changelog:** [CHANGELOG.md](CHANGELOG.md).
+**Contributing & security:** [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md) · [.github/SECURITY.md](.github/SECURITY.md) · **Changelog:** [CHANGELOG.md](CHANGELOG.md)
 
 ## Branches & releases
 
 | Branch / tag | Purpose |
 |--------------|---------|
-| [`main`](https://github.com/pgquery-narrative/pgquerynarrative/tree/main) | Latest development (Postgres-first query intelligence) |
-| [`stable-v2.0.0`](https://github.com/pgquery-narrative/pgquerynarrative/tree/stable-v2.0.0) | v2 release line — EXPLAIN API, 10M-row benchmark, parser validation, RLS/pgvector |
-| [`stable-v1.0.0`](https://github.com/pgquery-narrative/pgquerynarrative/tree/stable-v1.0.0) | v1 release line — AI narrative focus, pre-Postgres pivot |
-| Tag [`v2.0.0`](https://github.com/pgquery-narrative/pgquerynarrative/releases/tag/v2.0.0) | v2.0.0 release snapshot |
-| Tag [`v1.0.0`](https://github.com/pgquery-narrative/pgquerynarrative/releases/tag/v1.0.0) | v1.0.0 release snapshot |
+| [`main`](https://github.com/pgquery-narrative/pgquerynarrative/tree/main) | Latest development |
+| [`stable-v2.0.0`](https://github.com/pgquery-narrative/pgquerynarrative/tree/stable-v2.0.0) | v2 line — EXPLAIN, benchmark dataset, validation |
+| [`stable-v1.0.0`](https://github.com/pgquery-narrative/pgquerynarrative/tree/stable-v1.0.0) | v1 line — earlier AI-narrative focus |
+| Tag [`v2.0.0`](https://github.com/pgquery-narrative/pgquerynarrative/releases/tag/v2.0.0) | v2.0.0 release |
 
 ## License
 

--- a/docs/DEMO_RUNBOOK.md
+++ b/docs/DEMO_RUNBOOK.md
@@ -4,7 +4,7 @@ Timed walkthrough for a **solo portfolio / hiring demo** (15–20 min core + dee
 Postgres is the hero; AI is optional and governed.
 
 **One-line open:**  
-“PgQueryNarrative is Postgres-native query intelligence — safe read-only SQL, EXPLAIN triage, and optional AI narratives — so analytics teams don’t paste production credentials into a chatbot.”
+“PgQueryNarrative is Postgres-native query intelligence — safe read-only SQL, EXPLAIN triage, verified rewrite compare, and optional AI narratives — so analytics teams don’t paste production credentials into a chatbot.”
 
 ---
 
@@ -230,3 +230,17 @@ Expect validation error.
 | NYC relation missing | Migrate + `seed-nyc-docker` + allowlist `demo,opendata` + recreate app |
 | Multi-org script fails | `make migrate-docker` (need version ≥ 44) |
 | Port busy | `make stop` then bootstrap again |
+
+---
+
+## README GIF capture {#readme-gif-capture}
+
+Maintainer-only. Re-records `docs/assets/demo-workflow.gif` from a live UI walkthrough (finding → compare → report). Requires the **10M-row** seed and `EXPLAIN ANALYZE` enabled (Compose demo defaults).
+
+```bash
+make demo-bootstrap   # or: make seed-large-docker on an existing demo stack
+make demo-gif         # app must be up on http://127.0.0.1:8080
+```
+
+`make demo-gif-credible` bootstraps the large seed then records. Needs Playwright browsers + `ffmpeg`. Not part of the normal user Commands table in the root README.
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,58 +1,82 @@
 # PgQueryNarrative documentation
 
-Run read-only SQL against PostgreSQL, compute metrics and chart suggestions, and generate narrative reports via a configurable LLM. Web UI: [React SPA](ui-overview.md); automation: [REST API](api/README.md) and [CLI](usage/cli-usage.md).
+PostgreSQL **Query Investigation** workbench: safe read-only SQL, plan evidence, before/after compare, and engineering reports. Optional LLM narratives sit on top — they are not required for the core loop.
 
-**Recommended path:** [Quick start](getting-started/quickstart.md) → [LLM setup](getting-started/llm-setup.md) (for reports) → [Configuration](configuration.md).
+**Audience paths**
 
-**Local preview:** run `make docs` from the repo root, then open **http://localhost:8000** (MkDocs Material with search and navigation).
+| Path | Start |
+|------|--------|
+| Try in minutes | [Quick start](getting-started/quickstart.md) (`make demo`) |
+| Connect your DB | [Connect your PostgreSQL](getting-started/connect-postgres.md) |
+| Ship to prod | [Production — start here](ops/PRODUCTION.md#start-here) |
+| Trust & scope | [Trust model](trust-model.md) |
+
+**Recommended reading order:** [Concepts](concepts.md) → [Quick start](getting-started/quickstart.md) → [Trust model](trust-model.md) → [Configuration](configuration.md).
+
+**Local preview:** `make docs` from the repo root → **http://localhost:8000**.
+
+This file mirrors the MkDocs home page ([index.md](index.md)). Prefer **[index.md](index.md)** when browsing the docs site.
 
 ---
 
 ## Docs index
 
-| Section | Links |
-|--------|--------|
-| **Architecture** | [Project structure](../README.md#project-structure) (root README) — entrypoint, `app/`, API design, frontend, web handlers |
-| **API reference** | [API reference](api/README.md) — endpoints, request/response, errors · [Examples](api/examples.md) |
-| **UI overview** | [UI overview](ui-overview.md) — Query editor, saved queries, reports, Settings → Analytics |
-| **Configuration** | [Configuration](configuration.md) — Environment variables (server, DB, LLM, embeddings, metrics, security) |
-| **Analytics / Phases** | [Configuration – Metrics](configuration.md#metrics) — Trend, anomaly, forecast, correlation, smoothing; read-only in UI at Settings → Analytics |
-| **Deployment / Production** | [Deployment](reference/deployment.md) — Docker, Compose, Kubernetes, Helm · [Operations](reference/operations.md) — Health, monitoring |
-| **Troubleshooting** | [Troubleshooting](reference/troubleshooting.md) — Common issues and fixes |
+### Product
 
----
+| Document | Description |
+|----------|-------------|
+| [Concepts](concepts.md) | Investigation loop, evidence, EXPLAIN vs ANALYZE, what compare proves |
+| [Trust model](trust-model.md) | Readonly role, allowlists, what the app will not do |
+| [UI overview](ui-overview.md) | Investigate, compare, reports, Security & Trust |
+| [Demo runbook](DEMO_RUNBOOK.md) | Solo demo scenes + README GIF capture notes |
+| [Configuration](configuration.md) | Environment variables |
 
 ### Getting started
 
 | Document | Description |
 |----------|-------------|
-| [Installation](getting-started/installation.md) | Prerequisites, Docker and local run, verification |
-| [Quick start](getting-started/quickstart.md) | Minimal steps to run |
-| [LLM setup](getting-started/llm-setup.md) | LLM providers (Ollama, Gemini, Claude, OpenAI, Groq) and MCP |
-| [Embedded integration](getting-started/embedded.md) | Go library and HTTP middleware (Chi, Gin, Echo) |
+| [Quick start](getting-started/quickstart.md) | `make demo` and first investigation |
+| [Installation](getting-started/installation.md) | Docker and local prerequisites |
+| [Connect your PostgreSQL](getting-started/connect-postgres.md) | Readonly role, schemas, verify |
+| [LLM setup](getting-started/llm-setup.md) | Optional providers (Ollama, cloud) |
+| [Embedded integration](getting-started/embedded.md) | Go library / middleware |
 
-### User guides
-
-| Document | Description |
-|----------|-------------|
-| [CLI usage](usage/cli-usage.md) | Command-line interface for queries and reports |
-
-### Reference
+### API & automation
 
 | Document | Description |
 |----------|-------------|
-| [PostgreSQL extension](reference/postgres-extension.md) | Call the API from SQL |
-| [Semantic search (pgvector)](reference/semantic-search-pgvector.md) | Embeddings, similar-query search, RAG |
-| [Versioning and releases](reference/versioning-and-releases.md) | Versioning, changelog, release build |
+| [API reference](api/README.md) | Endpoints and errors |
+| [API examples](api/examples.md) | Investigation, compare, explain, run |
+| [CLI usage](usage/cli-usage.md) | Command-line workflows |
+
+### Operations
+
+| Document | Description |
+|----------|-------------|
+| [Deployment](reference/deployment.md) | Docker, Compose, Kubernetes, Helm |
+| [Production ops](ops/PRODUCTION.md) | Start-here checklist, security, monitoring |
+| [Operations](reference/operations.md) | Health, monitoring day-2 |
+| [Incident runbooks](ops/INCIDENT_RUNBOOKS.md) | Incident response |
+| [Troubleshooting](reference/troubleshooting.md) | Common failures |
+
+### Reference & evidence
+
+| Document | Description |
+|----------|-------------|
+| [Dataset](DATASET.md) | `demo.sales` partitions and 10M seed |
+| [Case study](case-studies/01-query-optimization.md) | Optimization walkthrough |
+| [PostgreSQL extension](reference/postgres-extension.md) | Call API from SQL |
+| [Semantic search (pgvector)](reference/semantic-search-pgvector.md) | Similar queries / RAG |
+| [Versioning](reference/versioning-and-releases.md) | Releases and changelog |
 
 ### Development
 
 | Document | Description |
 |----------|-------------|
-| [Development setup](development/setup.md) | Build, test, codegen, frontend |
-| [Testing](development/testing.md) | Unit, integration, E2E tests |
-| [Runbook](development/runbook.md) | Daily dev, before commit, tests, build & release |
+| [Development setup](development/setup.md) | Build, codegen, frontend |
+| [Testing](development/testing.md) | Unit, integration, E2E |
+| [Dev runbook](development/runbook.md) | Daily developer workflow |
 
 ---
 
-**Contributing & security:** [.github/CONTRIBUTING.md](../.github/CONTRIBUTING.md) · [.github/SECURITY.md](../.github/SECURITY.md). **Changelog:** [CHANGELOG.md](../CHANGELOG.md).
+**Contributing & security:** [.github/CONTRIBUTING.md](../.github/CONTRIBUTING.md) · [.github/SECURITY.md](../.github/SECURITY.md). **Changelog:** [CHANGELOG.md](../CHANGELOG.md). **Root README:** [../README.md](../README.md).

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -2,14 +2,37 @@
 
 REST API base: `http://localhost:8080/api/v1` (override with [Configuration](../configuration.md) server port). All request/response bodies are JSON. When `SECURITY_AUTH_ENABLED` is true, send `Authorization: Bearer <SECURITY_API_KEY>`; otherwise requests are unauthenticated. Rate limiting (when `SECURITY_RATE_LIMIT_RPM` > 0) returns 429. **OpenAPI 3:** `api/gen/http/openapi3.json` and `api/gen/http/openapi3.yaml` for codegen and API tooling.
 
+Flagship flow examples: [API examples — Query Investigation](examples.md#query-investigation-flagship). Concepts: [Concepts](../concepts.md).
+
+## Investigations
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/investigations` | Body: `{"title","sql", ...}`. Create investigation; runs plan analysis. Returns investigation with `explain` / findings. |
+| GET | `/investigations` | Query: `limit`, `offset`. List investigations. |
+| GET | `/investigations/{id}` | Get investigation with evidence, optional candidate + comparison. |
+| POST | `/investigations/{id}/candidate` | Body: `{"candidate_sql","analyze"}`. Attach rewrite and compare plans. |
+| POST | `/investigations/{id}/report` | Generate engineering investigation report; sets `report_id`. |
+
+## Workspace
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/workspace/overview` | Landing evidence summary (stats / attention counts). |
+| GET | `/workspace/regressions` | Regression inbox items. |
+| POST | `/workspace/regressions/{id}/acknowledge` | Acknowledge a regression. |
+| GET | `/demo/scenarios` | Guided demo scenarios (title, SQL, candidate). |
+| GET | `/trust` | Security & Trust snapshot for the UI. |
+
 ## Queries
 
 | Method | Path | Description |
 |--------|------|-------------|
-| POST | `/queries/run` | Body: `{"sql":"...", "limit": 100, "connection_id":"default"}`. `connection_id` optional. Run read-only SQL. Returns `columns`, `rows`, `row_count`, `execution_time_ms`, optional `period_comparison`, `chart_suggestions`. |
-| POST | `/queries/explain` | Body: `{"sql":"...", "analyze": false, "connection_id":"default"}`. `connection_id` optional. Run `EXPLAIN (FORMAT JSON)` on read-only SQL. Returns `total_cost`, `plan`, `findings` (seq scans, high-cost nodes), `execution_time_ms`. |
-| POST | `/queries/saved` | Body: `{"name","sql","tags","connection_id":"default"}`. `connection_id` optional. Save query. |
-| GET | `/queries/saved` | Query: `limit`, `offset`, `tags`, `connection_id`. List saved queries; optional connection filter. |
+| POST | `/queries/run` | Body: `{"sql":"...", "limit": 100, "connection_id":"default"}`. Run read-only SQL. |
+| POST | `/queries/explain` | Body: `{"sql":"...", "analyze": false, "connection_id":"default"}`. Run `EXPLAIN (FORMAT JSON)`. |
+| POST | `/queries/explain/compare` | Body: `{"before_sql","after_sql","analyze","connection_id"}`. Before/after plan metrics without an investigation record. |
+| POST | `/queries/saved` | Body: `{"name","sql","tags","connection_id":"default"}`. Save query. |
+| GET | `/queries/saved` | Query: `limit`, `offset`, `tags`, `connection_id`. List saved queries. |
 | GET | `/queries/saved/{id}` | Get saved query by ID. |
 | DELETE | `/queries/saved/{id}` | Delete saved query. |
 
@@ -23,33 +46,34 @@ REST API base: `http://localhost:8080/api/v1` (override with [Configuration](../
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/schema` | Allowed schemas, tables, columns. Query: `connection_id` (optional). Used by MCP `get_schema`. |
+| GET | `/schema` | Allowed schemas, tables, columns. Query: `connection_id` (optional). |
 
 ## Suggestions
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/suggestions/queries` | Query: `intent`, `limit` (default 5). Suggested SQL (curated + saved-query match). |
-| GET | `/suggestions/similar` | Query: `text` (required), `limit` (default 5). Saved queries semantically similar to text (embedding-based). Requires [embeddings](../reference/semantic-search-pgvector.md) enabled. |
-| POST | `/suggestions/ask` | Body: `{"question":"...", "connection_id":"default"}`. `connection_id` optional. Natural language → SQL → run → narrative report. Requires [LLM](../getting-started/llm-setup.md). |
-| POST | `/suggestions/explain` | Body: `{"sql":"..."}`. Plain-English explanation of SQL. Requires [LLM](../getting-started/llm-setup.md). |
+| GET | `/suggestions/queries` | Query: `intent`, `limit`. Suggested SQL. |
+| GET | `/suggestions/similar` | Query: `text`, `limit`. Semantic similar saved queries. Requires [embeddings](../reference/semantic-search-pgvector.md). |
+| POST | `/suggestions/ask` | Body: `{"question","connection_id"}`. NL → SQL → narrative. Requires [LLM](../getting-started/llm-setup.md). |
+| POST | `/suggestions/explain` | Body: `{"sql"}`. Plain-English SQL explanation. Requires [LLM](../getting-started/llm-setup.md). |
 
 ## Reports
 
 | Method | Path | Description |
 |--------|------|-------------|
-| POST | `/reports/generate` | Body: `{"sql":"...", "saved_query_id":"uuid", "connection_id":"default"}`. `connection_id` optional. Generate report (requires [LLM](../getting-started/llm-setup.md)). Returns `narrative`, `metrics`. |
-| GET | `/reports/{id}` | Get report. Metrics: `time_series`, `correlations`, `cohorts` (when [cohort shape](../configuration.md#cohort-analysis) present), `data_quality`, `perf_suggestions`, etc. |
-| GET | `/reports` | Query: `limit`, `offset`, `saved_query_id`, `connection_id`. List reports; optional connection filter. |
+| POST | `/reports/generate` | Body: `{"sql","saved_query_id","connection_id"}`. Narrative report path (often requires [LLM](../getting-started/llm-setup.md)). |
+| GET | `/reports/{id}` | Get report. |
+| GET | `/reports` | Query: `limit`, `offset`, `saved_query_id`, `connection_id`. List reports. |
 
 ## Errors
 
-Response JSON: `{"name","message","code"}`. Codes: `VALIDATION_ERROR`, `TIMEOUT_ERROR`, `NOT_FOUND`, `LLM_ERROR`, `UNAUTHORIZED` (401 when auth enabled and missing/invalid Bearer), `RATE_LIMIT_EXCEEDED` (429 when rate limit applies).
+Response JSON: `{"name","message","code"}`. Codes: `VALIDATION_ERROR`, `TIMEOUT_ERROR`, `NOT_FOUND`, `LLM_ERROR`, `UNAUTHORIZED`, `RATE_LIMIT_EXCEEDED`.
 
 ## See also
 
-- [API examples](examples.md) — Single run-query cURL example
-- [Configuration](../configuration.md) — Environment variables
-- [Deployment](../reference/deployment.md) — Running the API
-- [Embedded integration](../getting-started/embedded.md) — Library and middleware (different path prefix)
-- [Documentation index](../README.md)
+- [API examples](examples.md) — Investigation, compare, explain, run
+- [Trust model](../trust-model.md)
+- [Configuration](../configuration.md)
+- [Deployment](../reference/deployment.md)
+- [Embedded integration](../getting-started/embedded.md)
+- [Docs overview](../index.md)

--- a/docs/api/examples.md
+++ b/docs/api/examples.md
@@ -1,8 +1,77 @@
 # API examples
 
-Base URL: `http://localhost:8080` (or set port via [Configuration](../configuration.md)). Full endpoint list: [API reference](README.md).
+Base URL: `http://localhost:8080` (see [Configuration](../configuration.md)). Full endpoint list: [API reference](README.md).
 
-**Example — run query:**
+Product vocabulary: [Concepts](../concepts.md).
+
+---
+
+## Query Investigation (flagship)
+
+Create an investigation from SQL, attach a candidate rewrite (plan compare), then generate a report.
+
+```bash
+# 1) Create — returns id, explain findings, status
+INV=$(curl -s -X POST http://localhost:8080/api/v1/investigations \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "Slow dashboard query",
+    "sql": "SELECT product_category, SUM(total_amount) AS revenue FROM demo.sales WHERE DATE_TRUNC('\''month'\'', date) = DATE '\''2025-01-01'\'' GROUP BY product_category ORDER BY revenue DESC"
+  }')
+echo "$INV" | jq '{id, status, findings: [.explain.findings[]?.message][:3]}'
+ID=$(echo "$INV" | jq -r .id)
+
+# 2) Candidate rewrite + compare (set "analyze": true when server allows EXPLAIN ANALYZE)
+curl -s -X POST "http://localhost:8080/api/v1/investigations/${ID}/candidate" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "candidate_sql": "SELECT product_category, SUM(total_amount) AS revenue FROM demo.sales WHERE date >= '\''2025-01-01'\'' AND date < '\''2025-02-01'\'' GROUP BY product_category ORDER BY revenue DESC",
+    "analyze": true
+  }' | jq '{status, comparison: .comparison.metrics}'
+
+# 3) Engineering report
+curl -s -X POST "http://localhost:8080/api/v1/investigations/${ID}/report" \
+  -H "Content-Type: application/json" \
+  -d "{}" | jq '{status, report_id}'
+```
+
+List / fetch:
+
+```bash
+curl -s 'http://localhost:8080/api/v1/investigations?limit=5' | jq .
+curl -s "http://localhost:8080/api/v1/investigations/${ID}" | jq '{id, status, candidate_sql, report_id}'
+```
+
+Workspace helpers (landing / inbox / guided scenarios / trust):
+
+```bash
+curl -s http://localhost:8080/api/v1/workspace/overview | jq .
+curl -s http://localhost:8080/api/v1/demo/scenarios | jq .
+curl -s http://localhost:8080/api/v1/trust | jq .
+```
+
+---
+
+## Compare plans (standalone)
+
+Same before/after proof without an investigation record:
+
+```bash
+curl -s -X POST http://localhost:8080/api/v1/queries/explain/compare \
+  -H "Content-Type: application/json" \
+  -d '{
+    "before_sql": "SELECT product_category, SUM(total_amount) AS revenue FROM demo.sales WHERE DATE_TRUNC('\''month'\'', date) = DATE '\''2025-01-01'\'' GROUP BY product_category ORDER BY revenue DESC",
+    "after_sql": "SELECT product_category, SUM(total_amount) AS revenue FROM demo.sales WHERE date >= '\''2025-01-01'\'' AND date < '\''2025-02-01'\'' GROUP BY product_category ORDER BY revenue DESC",
+    "analyze": true,
+    "connection_id": "default"
+  }' | jq .
+```
+
+On the 10M-row seed, expect a **Partitions scanned** style metric moving from many partitions toward **1**.
+
+---
+
+## Run query
 
 ```bash
 curl -s -X POST http://localhost:8080/api/v1/queries/run \
@@ -12,11 +81,11 @@ curl -s -X POST http://localhost:8080/api/v1/queries/run \
 
 Response: `columns`, `rows`, `row_count`, `execution_time_ms`, optional `chart_suggestions`, `period_comparison` (when result has a time column and measures).
 
-**Example — explain query plan (seq scan detection):**
+---
 
-Requires a running stack (`make start-docker` or `make postgres-up` + app on port 8080). On the
-10M-row partitioned `demo.sales` dataset, filtering on `region` (no btree index on that column)
-produces sequential scans across partitions — one finding per scanned partition.
+## Explain query plan
+
+Requires a running stack (`make demo` / `make start-docker`). On the 10M-row partitioned `demo.sales` dataset, filtering on `region` (no btree index) produces sequential scans across partitions.
 
 ```bash
 curl -s -X POST http://localhost:8080/api/v1/queries/explain \
@@ -24,41 +93,9 @@ curl -s -X POST http://localhost:8080/api/v1/queries/explain \
   -d '{"sql":"SELECT product_category, SUM(total_amount) FROM demo.sales WHERE region = '\''North'\'' GROUP BY product_category","connection_id":"default"}'
 ```
 
-Expected response (truncated; `plan` is the full `EXPLAIN (FORMAT JSON)` array; costs vary with row count):
+Set `"analyze": true` to run `EXPLAIN (ANALYZE, FORMAT JSON)` when enabled server-side (executes the query; timeout-guarded).
 
-```json
-{
-  "sql": "SELECT product_category, SUM(total_amount) FROM demo.sales WHERE region = 'North' GROUP BY product_category",
-  "total_cost": 153486.8,
-  "execution_time_ms": 81,
-  "findings": [
-    {
-      "node_type": "Seq Scan",
-      "relation": "sales_2023_06",
-      "estimated_cost": 0,
-      "is_seq_scan": true,
-      "message": "Sequential scan on sales_2023_06 (estimated cost 0.00) — filter: (region = 'North'::text) — consider a btree index on filtered or joined columns"
-    },
-    {
-      "node_type": "Seq Scan",
-      "relation": "sales_2023_07",
-      "estimated_cost": 0,
-      "is_seq_scan": true,
-      "message": "Sequential scan on sales_2023_07 (estimated cost 0.00) — filter: (region = 'North'::text) — consider a btree index on filtered or joined columns"
-    },
-    {
-      "node_type": "Gather Merge",
-      "estimated_cost": 153486.66,
-      "is_seq_scan": false,
-      "message": "High-cost Gather Merge on unknown relation (estimated cost 153486.66, ≥50% of plan total)"
-    }
-  ],
-  "plan": [ { "Plan": { "Node Type": "Aggregate", "Total Cost": 153486.8, "…": "…" } } ]
-}
-```
-
-Findings order follows plan-tree traversal (high-cost parents like `Gather Merge` may appear
-before partition seq scans). Check seq-scan count:
+Seq-scan count check:
 
 ```bash
 curl -s -X POST http://localhost:8080/api/v1/queries/explain \
@@ -67,42 +104,32 @@ curl -s -X POST http://localhost:8080/api/v1/queries/explain \
   | jq '[.findings[] | select(.is_seq_scan)] | length'
 ```
 
-Expect **25** on the 10M-row partitioned dataset (`make seed-large-docker`); **1** on the small
-`make seed` dataset (single `demo.sales` seq scan).
+Expect many partition seq scans on `make seed-large-docker`; fewer on the small `make seed` / `make demo` dataset.
 
-Set `"analyze": true` to run `EXPLAIN (ANALYZE, FORMAT JSON)` (executes the query; timeout-guarded).
-On the same query, `execution_time_ms` is higher (~1s on 10M rows) but `total_cost` and findings
-shape match the estimate-only path.
+---
 
-**Example — semantic search over saved queries (pgvector):**
+## Semantic search over saved queries (pgvector)
 
-Requires embeddings enabled (`EMBEDDING_BASE_URL` + `EMBEDDING_MODEL` in `.env`) and at least
-one saved query. With `POSTGRES_IMAGE=pgvector/pgvector:pg16`, vectors are stored in
-`app.query_embeddings.embedding_vector` and ranked in Postgres via HNSW.
+Requires embeddings (`EMBEDDING_BASE_URL` + `EMBEDDING_MODEL`) and at least one saved query. See [Semantic search (pgvector)](../reference/semantic-search-pgvector.md).
 
 ```bash
-# Save a query (triggers embed + upsert)
 curl -s -X POST http://localhost:8080/api/v1/queries/saved \
   -H "Content-Type: application/json" \
   -d '{"name":"North rollup","sql":"SELECT region, SUM(total_amount) FROM demo.sales WHERE region = '\''North'\'' GROUP BY region"}'
 
-# Find similar saved queries
 curl -s 'http://localhost:8080/api/v1/suggestions/similar?text=regional%20revenue%20breakdown&limit=5' | jq .
 ```
 
-Response shape: `{ "suggestions": [ { "sql", "title", "source": "similar" }, ... ] }`.
-See [Semantic search (pgvector)](../reference/semantic-search-pgvector.md) for the full flow.
+---
 
-**Example — list connections:**
+## List connections
 
 ```bash
 curl -s http://localhost:8080/api/v1/connections
 ```
 
-Response:
-
 ```json
 {"items":[{"id":"default","name":"Default"},{"id":"prod","name":"Production"}]}
 ```
 
-**See also:** [API reference](README.md) · [Configuration](../configuration.md) · [Documentation index](../README.md)
+**See also:** [API reference](README.md) · [Connect your PostgreSQL](../getting-started/connect-postgres.md) · [Docs overview](../index.md)

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,70 @@
+# Concepts
+
+How PgQueryNarrative thinks about query problems — the vocabulary behind the UI, GIF, and API.
+
+## What problem this solves
+
+Teams often know a query is slow (dashboards, `pg_stat_statements`, user complaints) but lack a **repeatable path from symptom → plan evidence → verified fix → shareable write-up**. Pasting SQL into a chatbot skips the database’s own proof.
+
+PgQueryNarrative is a **PostgreSQL investigation workbench**: safe read-only SQL, EXPLAIN analysis, before/after compare, and engineering reports. An optional LLM can narrate; it is not required for the core loop.
+
+## Query Investigation
+
+An **investigation** is a first-class workflow object. It holds:
+
+| Piece | Meaning |
+|-------|---------|
+| Source SQL | The expensive or suspicious query |
+| Plan evidence | Parsed `EXPLAIN` / `EXPLAIN ANALYZE` tree + findings |
+| Candidate SQL | A proposed rewrite (or index-oriented alternative) |
+| Comparison | Side-by-side metrics (cost, time, partitions, buffers when available) |
+| Report | A durable engineering artifact you can share |
+
+Typical UI path: **Investigate** → guided scenario or paste SQL → review findings → **Compare plans** → **Generate report**.
+
+## What “evidence” means
+
+Evidence is **what Postgres reported**, not model opinion:
+
+- Plan node types (Seq Scan, Index Scan, Aggregate, …)
+- Estimated cost and (when ANALYZE is on) actual time / rows
+- Partition counts when the planner prunes range partitions
+- App findings that name anti-patterns (e.g. function-wrapped partition key)
+
+The product highlights those signals so a human can decide — it does not silently rewrite production SQL.
+
+## EXPLAIN vs EXPLAIN ANALYZE
+
+| Mode | What it does | When to use |
+|------|----------------|-------------|
+| `EXPLAIN` | Planner estimates only; does not execute the query body for timing | Fast triage, cheap to run |
+| `EXPLAIN ANALYZE` | Executes the query and records actual times/rows | Proof of a rewrite; needs timeouts and usually a replica |
+
+Server config gates ANALYZE (`SECURITY_EXPLAIN_ANALYZE_ENABLED`). Local demo Compose enables it so compare can show credible timings on the large seed.
+
+## What compare proves
+
+**Compare** runs plans for source SQL and candidate SQL and shows deltas. On the guided demo (partitioned `demo.sales`):
+
+- Bad predicate: `DATE_TRUNC('month', date) = …` → pruning blocked → many partitions scanned
+- Good predicate: `date >= … AND date < …` → pruning works → often **50 → 1** partitions on the 10M-row seed
+
+So “verified rewrite” means: **the database plan changed in the expected way**, measured by Postgres — not that an LLM preferred the new SQL.
+
+## Regression inbox
+
+The workspace can surface queries that look worse over time (from stats / polling). That is an **entry point** into investigation, not a separate product. You still land in the same evidence → compare → report loop.
+
+## Schema allowlist and demo data
+
+By default, user SQL may only touch schemas listed in `DATABASE_ALLOWED_SCHEMAS` (default `demo`). The bundled `demo.sales` table is range-partitioned by month so partition-pruning stories are reproducible. See [Dataset](DATASET.md) and [Trust model](trust-model.md).
+
+## Optional LLM layer
+
+Narratives and “Ask in natural language” use a configured provider (often local Ollama in demo). Investigation reports remain useful **without** an LLM when they are built from plan metrics and SQL. See [LLM setup](getting-started/llm-setup.md).
+
+## See also
+
+- [Trust model](trust-model.md) — what the app will and will not do
+- [Demo runbook](DEMO_RUNBOOK.md) — scene-by-scene walkthrough
+- [API examples](api/examples.md) — investigation create → candidate → report

--- a/docs/development/runbook.md
+++ b/docs/development/runbook.md
@@ -1,6 +1,8 @@
-# Runbook (personal)
+# Dev runbook
 
-One-place reference for running, testing, and shipping PgQueryNarrative. See also [Setup](setup.md) and [Testing](testing.md).
+Daily developer workflow for running, testing, and shipping PgQueryNarrative. This is **not** a system architecture overview — for product vocabulary see [Concepts](../concepts.md); for structure see the [root README](../../README.md#project-structure).
+
+Also: [Setup](setup.md) · [Testing](testing.md).
 
 ---
 

--- a/docs/getting-started/connect-postgres.md
+++ b/docs/getting-started/connect-postgres.md
@@ -1,0 +1,76 @@
+# Connect your PostgreSQL
+
+Point PgQueryNarrative at **your** database (usually a replica) with a dedicated read-only role. For the bundled demo dataset, use [Quick start](quickstart.md) instead.
+
+Read [Trust model](../trust-model.md) before opening production-adjacent data.
+
+## 1. Create a read-only role
+
+On the target PostgreSQL (example — adjust names and schemas):
+
+```sql
+CREATE ROLE pqn_readonly LOGIN PASSWORD 'choose-a-strong-secret';
+
+-- Example: analytics reporting schema only
+GRANT CONNECT ON DATABASE your_db TO pqn_readonly;
+GRANT USAGE ON SCHEMA reporting TO pqn_readonly;
+GRANT SELECT ON ALL TABLES IN SCHEMA reporting TO pqn_readonly;
+ALTER DEFAULT PRIVILEGES IN SCHEMA reporting
+  GRANT SELECT ON TABLES TO pqn_readonly;
+```
+
+Prefer a **replica**. Do not use a superuser or a role that can write application data.
+
+## 2. Configure the app
+
+Minimum environment (see [Configuration](../configuration.md)):
+
+```bash
+# App DB (saved queries, reports, orgs) — can be the Compose Postgres
+DATABASE_HOST=...
+DATABASE_USER=pgquerynarrative_app
+DATABASE_PASSWORD=...
+
+# Analytical queries — your replica + readonly role
+DATABASE_READONLY_USER=pqn_readonly
+DATABASE_READONLY_PASSWORD=...
+DATABASE_ALLOWED_SCHEMAS=reporting
+QUERY_TIMEOUT=30s
+```
+
+For a **second** analytical source (in addition to `default`), use `DATABASE_CONNECTIONS_JSON` and pick connections in the UI / API `connection_id`.
+
+## 3. Allowlist only what investigators need
+
+`DATABASE_ALLOWED_SCHEMAS` is a hard allowlist enforced in the query validator. Start narrow (one reporting schema or a set of views). Never put `app` (or your product’s private schema) on that list.
+
+## 4. Timeouts and EXPLAIN ANALYZE
+
+| Setting | Guidance |
+|---------|----------|
+| `QUERY_TIMEOUT` | Keep tight on shared replicas (e.g. 15–30s); raise only for approved ANALYZE demos |
+| `SECURITY_EXPLAIN_ANALYZE_ENABLED` | Off unless you accept that compare may **execute** candidate SQL |
+| Result size limits | Keep defaults until you know report workloads |
+
+## 5. Verify
+
+```bash
+curl -s http://localhost:8080/ready
+curl -s http://localhost:8080/api/v1/connections
+curl -s -X POST http://localhost:8080/api/v1/queries/run \
+  -H "Content-Type: application/json" \
+  -d '{"sql":"SELECT 1","limit":1}'
+```
+
+Then open **Investigate**, paste a real expensive query from that schema, and run compare only after you understand ANALYZE policy.
+
+## 6. Production checklist
+
+When leaving laptop demo mode: [Production ops — start here](../ops/PRODUCTION.md#start-here).
+
+## See also
+
+- [Trust model](../trust-model.md)
+- [Configuration](../configuration.md)
+- [Installation](installation.md)
+- [API examples](../api/examples.md)

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -2,6 +2,8 @@
 
 Prerequisites and run methods for PgQueryNarrative: Docker (recommended) or local build from source.
 
+**First time?** Prefer [Quick start](quickstart.md) (`make demo`) — it is the supported guided path. Use this page when you need prerequisites detail, a from-source build, or non-demo wiring. Connecting a real database: [Connect your PostgreSQL](connect-postgres.md).
+
 ## Prerequisites
 
 | Context | Requirements |
@@ -10,20 +12,26 @@ Prerequisites and run methods for PgQueryNarrative: Docker (recommended) or loca
 | **Local build & run** | Go 1.25+, PostgreSQL 16+ (or Docker for DB only). |
 | **Full web UI from source** | Node.js and npm (to build the [React SPA](../development/setup.md)). |
 
-Report generation requires an LLM. See [LLM setup](llm-setup.md) and [Configuration – LLM](../configuration.md#llm).
+Optional narratives require an LLM — [LLM setup](llm-setup.md). Investigation compare/report work without one.
 
 ## Docker (recommended)
 
-Single command starts PostgreSQL, runs migrations and seed, then the application.
+Guided demo (Postgres + app + seed):
 
 ```bash
-git clone <repository-url>
+git clone https://github.com/pgquery-narrative/pgquerynarrative.git
 cd pgquerynarrative
+make demo
+```
+
+Compose without the demo helper:
+
+```bash
 make start-docker
 ```
 
 - **Stack:** Root [docker-compose.yml](../../docker-compose.yml) (PostgreSQL + app). App image from root [Dockerfile](../../Dockerfile).
-- **Endpoints:** Web UI (React SPA) and API at **http://localhost:8080**. Health: [GET /health](../reference/operations.md#health-checks), [GET /ready](../reference/operations.md#health-checks).
+- **Endpoints:** Web UI and API at **http://localhost:8080**. Health: [GET /health](../reference/operations.md#health-checks), [GET /ready](../reference/operations.md#health-checks).
 
 For production-style image and Compose, see [Deployment – Docker](../reference/deployment.md#docker).
 
@@ -33,7 +41,7 @@ For production-style image and Compose, see [Deployment – Docker](../reference
 
 2. **Clone and setup:**
    ```bash
-   git clone <repository-url>
+   git clone https://github.com/pgquery-narrative/pgquerynarrative.git
    cd pgquerynarrative
    make setup
    make generate
@@ -53,14 +61,15 @@ For production-style image and Compose, see [Deployment – Docker](../reference
 ## Verify
 
 - **Readiness (DB):** `curl -s http://localhost:8080/ready`
-- **API:** `curl http://localhost:8080/api/v1/queries/saved`
+- **API:** `curl -s http://localhost:8080/api/v1/demo/scenarios | head`
 
 See [Operations – Health checks](../reference/operations.md#health-checks) for probe endpoints.
 
 ## PostgreSQL versions
 
+
 Supported: 16, 17, 18. Docker default image: `postgres:18-alpine`. Override: `POSTGRES_IMAGE=postgres:17-alpine make start-docker`.
 
 ## See also
 
-- [Quick start](quickstart.md) · [Configuration](../configuration.md) · [Deployment](../reference/deployment.md) · [Documentation index](../README.md)
+- [Quick start](quickstart.md) · [Connect your PostgreSQL](connect-postgres.md) · [Configuration](../configuration.md) · [Docs overview](../index.md)

--- a/docs/getting-started/llm-setup.md
+++ b/docs/getting-started/llm-setup.md
@@ -1,6 +1,8 @@
 # LLM setup
 
-Report generation requires an LLM. Supported providers: **Ollama** (local), **Gemini**, **Claude**, **OpenAI**, **Groq**. Set [Configuration – LLM](../configuration.md#llm) variables: `LLM_PROVIDER`, `LLM_MODEL`, and for cloud providers `LLM_API_KEY`.
+Optional **narrative** and **Ask** flows require an LLM. **Query Investigation** (plan findings, compare, engineering report from evidence) works without one.
+
+Supported providers: **Ollama** (local), **Gemini**, **Claude**, **OpenAI**, **Groq**. Set [Configuration – LLM](../configuration.md#llm) variables: `LLM_PROVIDER`, `LLM_MODEL`, and for cloud providers `LLM_API_KEY`.
 
 ## Ollama (local)
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,44 +1,69 @@
 # Quick start
 
-Minimal steps to run PgQueryNarrative.
+Get a guided **Query Investigation** running in minutes.
 
 ## Prerequisites
 
-- **Docker:** Docker and Docker Compose, or  
-- **Local:** PostgreSQL 16+ and Go 1.25+ (see [Installation](installation.md) for full prerequisites).
+- **Docker** and Docker Compose (recommended), or  
+- **Local:** PostgreSQL 16+ and Go 1.25+ — see [Installation](installation.md)
 
-## Docker
-
-```bash
-git clone <repository-url>
-cd pgquerynarrative
-make start-docker
-```
-
-Uses root [docker-compose.yml](../../docker-compose.yml) (PostgreSQL + app). App at **http://localhost:8080**. For production image and Compose: [Deployment](../reference/deployment.md).
-
-For multi-database setups, configure `DATABASE_CONNECTIONS_JSON` and `DATABASE_DEFAULT_CONNECTION_ID` before starting (see [Configuration – Multiple database connections](../configuration.md#multiple-database-connections)).
-
-## Local PostgreSQL
+## Guided demo (recommended)
 
 ```bash
-git clone <repository-url>
+git clone https://github.com/pgquery-narrative/pgquerynarrative.git
 cd pgquerynarrative
-pg_isready   # ensure Postgres is running
-make start-local
+make demo
 ```
 
-Requires [Installation](installation.md) steps (setup, generate, build, db-init, migrate, seed) to have been run once.
+Open **http://localhost:8080**:
+
+1. Click **Start guided demo** or open **Investigate**
+2. Choose **Slow dashboard query**
+3. Review plan findings (e.g. function-wrapped date → blocked partition pruning)
+4. Click **Compare plans** on the range-predicate rewrite
+5. Click **Generate report**
+
+Vocabulary: [Concepts](../concepts.md). Scene timing: [Demo runbook](../DEMO_RUNBOOK.md).
+
+For large-seed partition counts (≈10M rows, 50→1 style proof):
+
+```bash
+make demo-bootstrap
+```
+
+## Other ways to run
+
+=== "Docker Compose"
+
+    ```bash
+    make start-docker
+    ```
+
+    App: **http://localhost:8080**. Production-oriented images: [Deployment](../reference/deployment.md).
+
+=== "Local app + existing Postgres"
+
+    ```bash
+    pg_isready
+    make start-local
+    ```
+
+    Requires [Installation](installation.md) (setup, generate, build, db-init, migrate, seed) once.
+
+## Connect your own database
+
+Leaving the `demo` schema: [Connect your PostgreSQL](connect-postgres.md) and [Trust model](../trust-model.md).
 
 ## Next steps
 
 | Action | Link |
 |--------|------|
-| **Web UI (React SPA)** | http://localhost:8080 — query editor, saved queries, reports, export |
-| **CLI** | `make cli CMD='query "SELECT * FROM demo.sales LIMIT 5"'` — [CLI usage](../usage/cli-usage.md) |
-| **API** | [API example](../api/examples.md) |
-| **Reports** | Configure an [LLM](llm-setup.md) for narrative generation |
+| Understand the loop | [Concepts](../concepts.md) |
+| UI map | [UI overview](../ui-overview.md) |
+| API investigation flow | [API examples](../api/examples.md) |
+| Optional narratives | [LLM setup](llm-setup.md) |
+| Production | [Production — start here](../ops/PRODUCTION.md#start-here) |
 
 ## See also
 
-- [Installation](installation.md) · [LLM setup](llm-setup.md) · [Configuration](../configuration.md) · [Documentation index](../README.md)
+[Installation](installation.md) · [Configuration](../configuration.md) · [Docs overview](../index.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,14 +1,23 @@
 # PgQueryNarrative
 
-**PostgreSQL query intelligence that shows its evidence.** Run read-only SQL against PostgreSQL, analyze execution plans, compare improvements, and produce engineering-ready reports — with an optional LLM narrative layer on top.
+**PostgreSQL query intelligence that shows its evidence.** Investigate expensive queries with plan findings, compare rewrites, and produce engineering-ready reports — with an optional LLM narrative layer on top.
 
-Web UI: [UI overview](ui-overview.md) · Automation: [REST API](api/README.md) and [CLI](usage/cli-usage.md).
+| Path | Link |
+|------|------|
+| Try the demo | [Quick start](getting-started/quickstart.md) |
+| Connect your database | [Connect your PostgreSQL](getting-started/connect-postgres.md) |
+| Ship to production | [Production — start here](ops/PRODUCTION.md#start-here) |
+| Trust & scope | [Trust model](trust-model.md) |
+| How the product thinks | [Concepts](concepts.md) |
+
+Web UI: [UI overview](ui-overview.md) · API: [Reference](api/README.md) · [Examples](api/examples.md) · CLI: [CLI usage](usage/cli-usage.md)
 
 ## Recommended path
 
-1. [Quick start](getting-started/quickstart.md)
-2. [LLM setup](getting-started/llm-setup.md) (for narrative reports)
-3. [Configuration](configuration.md)
+1. [Concepts](concepts.md) — investigation, evidence, what compare proves  
+2. [Quick start](getting-started/quickstart.md) — `make demo`  
+3. [Trust model](trust-model.md) — then [Connect your PostgreSQL](getting-started/connect-postgres.md) when leaving the demo schema  
+4. [LLM setup](getting-started/llm-setup.md) — only if you want narratives / Ask  
 
 ## One-command demo
 
@@ -16,26 +25,31 @@ Web UI: [UI overview](ui-overview.md) · Automation: [REST API](api/README.md) a
 make demo
 ```
 
-Open **http://localhost:8080** and follow the guided Query Investigation workflow. See [Demo runbook](DEMO_RUNBOOK.md) for scene-by-scene details.
+Open **http://localhost:8080** → **Investigate** → **Slow dashboard query** → **Compare plans** → **Generate report**.
+
+Scene-by-scene: [Demo runbook](DEMO_RUNBOOK.md). Large seed: `make demo-bootstrap`.
 
 ## Documentation map
 
 | Topic | Document |
 |-------|----------|
-| Architecture & daily dev | [Development runbook](development/runbook.md) |
+| Concepts & trust | [Concepts](concepts.md) · [Trust model](trust-model.md) |
+| Getting started | [Quick start](getting-started/quickstart.md) · [Installation](getting-started/installation.md) · [Connect Postgres](getting-started/connect-postgres.md) |
+| Product guides | [UI overview](ui-overview.md) · [Demo runbook](DEMO_RUNBOOK.md) · [Configuration](configuration.md) |
 | API | [API reference](api/README.md) · [Examples](api/examples.md) |
-| Deployment | [Deployment](reference/deployment.md) · [Production checklist](ops/PRODUCTION.md) |
-| Operations | [Operations](reference/operations.md) · [Incident runbooks](ops/INCIDENT_RUNBOOKS.md) |
+| Deployment & ops | [Deployment](reference/deployment.md) · [Production](ops/PRODUCTION.md) · [Operations](reference/operations.md) · [Incidents](ops/INCIDENT_RUNBOOKS.md) |
 | Troubleshooting | [Troubleshooting](reference/troubleshooting.md) |
+| Dataset & case study | [Dataset](DATASET.md) · [Query optimization](case-studies/01-query-optimization.md) |
+| Development | [Setup](development/setup.md) · [Testing](development/testing.md) · [Dev runbook](development/runbook.md) |
 
 ## Local preview
-
-Browse this site with search and navigation at **http://localhost:8000**:
 
 ```bash
 make docs
 ```
 
+Then open **http://localhost:8000**.
+
 ---
 
-**Contributing & security:** [CONTRIBUTING.md](https://github.com/pgquerynarrative/pgquerynarrative/blob/main/.github/CONTRIBUTING.md) · [SECURITY.md](https://github.com/pgquerynarrative/pgquerynarrative/blob/main/.github/SECURITY.md) · **Changelog:** [CHANGELOG.md](https://github.com/pgquerynarrative/pgquerynarrative/blob/main/CHANGELOG.md)
+**Contributing & security:** [CONTRIBUTING.md](https://github.com/pgquery-narrative/pgquerynarrative/blob/main/.github/CONTRIBUTING.md) · [SECURITY.md](https://github.com/pgquery-narrative/pgquerynarrative/blob/main/.github/SECURITY.md) · **Changelog:** [CHANGELOG.md](https://github.com/pgquery-narrative/pgquerynarrative/blob/main/CHANGELOG.md)

--- a/docs/ops/PRODUCTION.md
+++ b/docs/ops/PRODUCTION.md
@@ -6,7 +6,21 @@ This repo ships a **Docker Compose dev stack** (`postgres:16-alpine`, volume
 schema `demo` with partitioned `demo.sales`). The sections below map directly to
 those artifacts — adapt hostnames, credentials, and retention to your environment.
 
-**Related:** [Demo dataset](../DATASET.md) · [Query optimization case study](../case-studies/01-query-optimization.md) · [Migrations](../../app/db/migrations/)
+**Related:** [Trust model](../trust-model.md) · [Connect your PostgreSQL](../getting-started/connect-postgres.md) · [Demo dataset](../DATASET.md) · [Query optimization case study](../case-studies/01-query-optimization.md) · [Migrations](../../app/db/migrations/)
+
+---
+
+## Start here {#start-here}
+
+Use this page when leaving the laptop demo. Suggested order:
+
+1. Confirm scope fits an **internal** deployment on a **replica** + **read-only role** — [§0 Supported production scope](#0-supported-production-scope) and [Trust model](../trust-model.md)
+2. Wire credentials and `DATABASE_ALLOWED_SCHEMAS` — [Connect your PostgreSQL](../getting-started/connect-postgres.md)
+3. Skim [§4 Security model](#4-security-model-defense-in-depth) and enable StrictMode expectations for your environment
+4. Set backups / migrations / alerts — [§1](#1-backup-and-restore), [§2](#2-migration-strategy-expandcontract--golang-migrate), [§3](#3-monitoring-and-alerts)
+5. Run the [Internal pilot acceptance checklist](#internal-pilot-acceptance-checklist) before wider rollout
+
+Still exploring locally? Prefer [Quick start](../getting-started/quickstart.md) (`make demo`) instead of this document.
 
 ---
 

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,0 +1,59 @@
+# Trust model
+
+Plain-language scope for security reviewers and operators. Details and checklists: [Production ops](ops/PRODUCTION.md).
+
+## What PgQueryNarrative is for
+
+- **Internal** analytics / engineering teams investigating expensive PostgreSQL queries
+- Running against a **dedicated read-only role**, ideally on a **replica**
+- Surfacing **plan evidence** and producing **engineering reports**
+
+Public multi-tenant SaaS and “paste production credentials into a chatbot” are **non-goals**.
+
+## What it will do
+
+| Behavior | Mechanism |
+|----------|-----------|
+| Run user SQL read-only | Separate `DATABASE_READONLY_*` credentials; app pool is for app tables only |
+| Bound result size and time | `QUERY_TIMEOUT`, result/cell/column limits |
+| Restrict schemas | `DATABASE_ALLOWED_SCHEMAS` (default `demo`; never include `app`) |
+| Validate statements | Single-statement checks; write / DDL patterns blocked |
+| Explain and compare | `EXPLAIN` / optional `EXPLAIN ANALYZE` when enabled server-side |
+| Audit sensitive LLM use | Policy flags + audit events when cloud LLM data egress is allowed |
+
+## What it will not do
+
+- **Execute writes or DDL** through the query runner (insert/update/delete/create/drop, etc.)
+- **Grant itself** broader database rights than the roles you configure
+- **Bypass** the schema allowlist for ad-hoc exploration of system catalogs you did not allow
+- **Send row data to a cloud LLM** unless you explicitly enable that path (`LLM_ALLOW_EXTERNAL_DATA` and related flags — default is fail-closed for cloud egress)
+- **Replace** your DBA review — findings are triage signals; you own production changes
+
+## Two database roles (intentional)
+
+| Role | Purpose |
+|------|---------|
+| App role (`DATABASE_USER`) | Migrations, saved queries, reports, org metadata |
+| Read-only role (`DATABASE_READONLY_USER`) | All user-facing SQL and EXPLAIN |
+
+If both point at the same superuser-like account, you have defeated the model. Use a true read-only grant set in production.
+
+## Demo vs your database
+
+| Mode | Schemas | Intent |
+|------|---------|--------|
+| Guided demo | `demo` (and optional `opendata`) | Reproducible partition-pruning story |
+| Your Postgres | Schemas you allowlist + grants you give the readonly role | Real investigations |
+
+Connecting your own database: [Connect your PostgreSQL](getting-started/connect-postgres.md).
+
+## UI visibility
+
+The workbench **Security & Trust** page (`GET /api/v1/trust`) reflects configured hardening so operators can see what is enabled locally vs production StrictMode expectations.
+
+## See also
+
+- [Connect your PostgreSQL](getting-started/connect-postgres.md)
+- [Configuration](configuration.md) — security and database variables
+- [Production ops](ops/PRODUCTION.md) — defense in depth, StrictMode, checklists
+- [Concepts](concepts.md)

--- a/docs/ui-overview.md
+++ b/docs/ui-overview.md
@@ -1,12 +1,35 @@
 # UI overview
 
-The web UI is a React SPA (Vite, Tailwind CSS, shadcn/ui) built from [`frontend/`](../frontend/) and served at `/` when running the app. It provides:
+The web UI is a React SPA (Vite, Tailwind CSS, shadcn/ui) built from [`frontend/`](../frontend/) and served at `/`.
 
-- **Query editor** — Schema browser, SQL suggestions, and **Ask** (natural language → SQL + report).
-- **Saved queries** — List, create, edit, delete; run and generate reports from a saved query.
-- **Reports** — List reports; open a report to view narrative, metrics (time-series, forecast, correlations, cohorts when applicable), and export (HTML/PDF).
-- **Connection-aware workflows** — Connection picker in Query Runner/Ask; schema browser refreshes by selected connection; Saved Queries and Reports show `connection_id` badges and support filtering by connection.
+## Flagship: Query Investigation
 
-Read-only analytics settings (e.g. trend threshold, anomaly sigma) are shown in **Settings → Analytics**; values come from [Configuration](configuration.md#metrics).
+Primary path for the product story:
 
-**See also:** [Quick start](getting-started/quickstart.md) · [API reference](api/README.md) · [Documentation index](README.md)
+1. **Investigate** (or **Start guided demo** from the landing workspace)
+2. Open a scenario (e.g. **Slow dashboard query**) or paste SQL
+3. Review **findings** from the execution plan
+4. Edit or accept a **candidate** rewrite → **Compare plans**
+5. **Generate report** → engineering investigation report
+
+Concepts behind each step: [Concepts](concepts.md). Timed demo: [Demo runbook](DEMO_RUNBOOK.md).
+
+## Other surfaces
+
+| Area | What it does |
+|------|----------------|
+| **Workspace / regression inbox** | Entry points from workload signals into investigations |
+| **Query runner** | Ad-hoc read-only SQL, schema browser, connection picker |
+| **Ask** | Natural language → SQL (optional LLM) |
+| **Saved queries** | Persist and re-run; connection badges / filters |
+| **Reports** | List and open reports; HTML/PDF export where enabled |
+| **Security & Trust** | Shows configured hardening (readonly, allowlists, ANALYZE, etc.) |
+| **Settings → Analytics** | Read-only metrics thresholds from [Configuration](configuration.md#metrics) |
+
+## Connections
+
+Query Runner, Ask, Saved Queries, and Investigations can target a `connection_id` when multiple analytical sources are configured (`DATABASE_CONNECTIONS_JSON`).
+
+## See also
+
+[Quick start](getting-started/quickstart.md) · [Trust model](trust-model.md) · [API examples](api/examples.md) · [Docs overview](index.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: PgQueryNarrative
 site_description: PostgreSQL query intelligence — safe read-only SQL, plan analysis, and evidence-backed reports.
-site_url: https://github.com/pgquerynarrative/pgquerynarrative
+site_url: https://github.com/pgquery-narrative/pgquerynarrative
 
 extra_css:
   - stylesheets/extra.css
@@ -48,13 +48,16 @@ theme:
 
 extra:
   generator: false
-  repo_url: https://github.com/pgquerynarrative/pgquerynarrative
+  repo_url: https://github.com/pgquery-narrative/pgquerynarrative
 
 nav:
   - Overview: index.md
+  - Concepts: concepts.md
+  - Trust model: trust-model.md
   - Getting started:
       - Quick start: getting-started/quickstart.md
       - Installation: getting-started/installation.md
+      - Connect your PostgreSQL: getting-started/connect-postgres.md
       - LLM setup: getting-started/llm-setup.md
       - Embedded integration: getting-started/embedded.md
   - User guides:
@@ -80,6 +83,6 @@ nav:
   - Development:
       - Setup: development/setup.md
       - Testing: development/testing.md
-      - Runbook: development/runbook.md
+      - Dev runbook: development/runbook.md
   - Case studies:
       - Query optimization: case-studies/01-query-optimization.md


### PR DESCRIPTION
## Summary
- Slim README around `make demo` with Try / Connect / Ship / Trust doors
- Add Concepts, Trust model, and Connect your PostgreSQL guides
- Rewrite docs hub + MkDocs nav for Query Investigation; fix org URLs
- API reference/examples cover investigations, compare, and workspace
- Demote GIF capture to Demo runbook; add Production start-here

Fixes #96

## Test plan
- [ ] Skim root README — one primary path, no demo-gif in Commands
- [ ] Open docs/index.md and Concepts / Trust / Connect pages
- [ ] Confirm PRODUCTION.md has Start here and API examples show investigation curl
- [ ] Optional: `make docs` and click through MkDocs nav

## Summary by Sourcery

Restructure the README and documentation hub to center the Query Investigation workflow and provide clearer entry paths for demo, database connection, and production use.

New Features:
- Add dedicated concepts and trust-model documentation pages to explain investigation vocabulary and security posture.
- Introduce a Connect your PostgreSQL guide for wiring a real read-only database connection.
- Document investigation, compare, workspace, and trust endpoints in API examples and reference, highlighting the flagship Query Investigation flow.

Enhancements:
- Simplify and reframe the root README around Try / Connect / Ship / Trust paths and the guided demo flow.
- Reorganize docs index, UI overview, quickstart, installation, and production ops content into audience-oriented paths with clearer recommended reading order.
- Update MkDocs navigation, site URLs, and development runbook naming to match the new documentation structure and repo location.
- Clarify LLM usage as optional on top of the core investigation loop throughout docs.

Documentation:
- Add guidance for leaving the demo schema and connecting real databases with read-only roles, allowlists, and timeouts.
- Highlight a production start-here checklist and trust model for operators moving to internal deployments.
- Move README GIF capture details into the demo runbook instead of core user commands.
- Expand and reorganize documentation maps to emphasize concepts, trust, operations, and evidence-focused case studies.